### PR TITLE
minor fixes to ScheduledActivityTest

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduledActivityTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduledActivityTest.java
@@ -37,8 +37,8 @@ public class ScheduledActivityTest {
 
     @Before
     public void before() {
-        developer = TestUserHelper.createAndSignInUser(SchedulePlanTest.class, true, Roles.DEVELOPER);
-        user = TestUserHelper.createAndSignInUser(SchedulePlanTest.class, true);
+        developer = TestUserHelper.createAndSignInUser(ScheduledActivityTest.class, true, Roles.DEVELOPER);
+        user = TestUserHelper.createAndSignInUser(ScheduledActivityTest.class, true);
 
         developerClient = developer.getSession().getDeveloperClient();
         userClient = user.getSession().getUserClient();
@@ -66,8 +66,12 @@ public class ScheduledActivityTest {
                 developerClient.deleteSchedulePlan(plan.getGuid());
             }
         } finally {
-            developer.signOutAndDeleteUser();
-            user.signOutAndDeleteUser();
+            if (developer != null) {
+                developer.signOutAndDeleteUser();
+            }
+            if (user != null) {
+                user.signOutAndDeleteUser();
+            }
         }
     }
     


### PR DESCRIPTION
1. Create test accounts using ScheduledActivityTest.class instead of SchedulePlanTest to reduce the (already low) chance of collision.
2. Add null check before deleting users.

Testing done:
- ran ScheduledActivityTest against staging
