### PR TITLE
Minor schema test changes in preparation of upcoming mutable schema changes

### DIFF
--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -7,9 +7,9 @@
     </encoder>
   </appender>
 
-  <logger name="org.sagebionetworks.bridge.sdk.BaseApiCaller" level="debug" />
+  <logger name="org.sagebionetworks.bridge.sdk.BaseApiCaller" level="warn" />
 
-  <root level="debug">
+  <root level="info">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>


### PR DESCRIPTION
There are a few minor changes in mutable schema validation. Before we push those changes server-side, we need to make some adjustments to the integ tests. In particular:
- Split the schema test for "optional values" to create separate fields for various field properties, instead of one mega-field with all properties.
- Added fields must have minAppVersion specified.

These are technically breaking changes, but given there are no automated processes that use the new field properties or update schema revisions in place, these changes should be safe to make.

Testing done:
- Ran against local server to verify compatibility with changes.
- Ran against dev to verify compatibility with old code.
