### PR TITLE
no longer able to add required fields to schemas

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
@@ -276,9 +276,9 @@ public class UploadSchemaTest {
         UploadFieldDefinition barMaxAppVersion = new UploadFieldDefinition.Builder().withName("bar")
                 .withType(UploadFieldType.STRING).withMaxAppVersion(42).build();
 
-        // This field will be added later. Needs minAppVersion field.
+        // This field will be added later. Needs to be optional.
         UploadFieldDefinition bazField = new UploadFieldDefinition.Builder().withName("baz")
-                .withType(UploadFieldType.STRING).withMinAppVersion(39).build();
+                .withType(UploadFieldType.STRING).withRequired(false).build();
 
         // create schema - Start with rev2 to test new v4 semantics.
         List<UploadFieldDefinition> fieldDefListV1 = ImmutableList.of(fooField, barField);


### PR DESCRIPTION
I messed up and neglected to change this when I dummied out min/maxAppVersion validation in https://github.com/Sage-Bionetworks/BridgePF/pull/1236 This updates the schema integ tests to only add optional fields.

Tested against both my local server and against devo.
