### PR TITLE
Moving tests to new java-jdk classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>java-sdk</artifactId>
-            <version>0.11.0</version>
+            <version>0.11.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>java-sdk</artifactId>
-            <version>0.11.3</version>
+            <version>0.11.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthenticationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthenticationTest.java
@@ -2,83 +2,109 @@ package org.sagebionetworks.bridge.sdk.integration;
 
 import static org.junit.Assert.*;
 
+import java.io.IOException;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.sagebionetworks.bridge.sdk.ClientProvider;
+import org.sagebionetworks.bridge.sdk.ClientManager;
 import org.sagebionetworks.bridge.sdk.Config;
-import org.sagebionetworks.bridge.sdk.Config.Props;
-import org.sagebionetworks.bridge.sdk.StudyClient;
-import org.sagebionetworks.bridge.sdk.integration.TestUserHelper.TestUser;
-import org.sagebionetworks.bridge.sdk.exceptions.BridgeSDKException;
-import org.sagebionetworks.bridge.sdk.models.accounts.EmailCredentials;
-import org.sagebionetworks.bridge.sdk.models.accounts.SignInCredentials;
-import org.sagebionetworks.bridge.sdk.models.accounts.StudyParticipant;
-import org.sagebionetworks.bridge.sdk.models.studies.Study;
+import org.sagebionetworks.bridge.sdk.integration.TestUserHelper2.TestUser;
+import org.sagebionetworks.bridge.sdk.rest.api.AuthenticationApi;
+import org.sagebionetworks.bridge.sdk.rest.api.ForAdminsApi;
+import org.sagebionetworks.bridge.sdk.rest.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.sdk.rest.model.Email;
+import org.sagebionetworks.bridge.sdk.rest.model.SignIn;
+import org.sagebionetworks.bridge.sdk.rest.model.SignUp;
+import org.sagebionetworks.bridge.sdk.rest.model.Study;
 
 @Category(IntegrationSmokeTest.class)
 public class AuthenticationTest {
 
+    private static TestUser testUser;
+    private static AuthenticationApi authApi;
+    
+    @BeforeClass
+    public static void beforeClass() throws IOException {
+        testUser = TestUserHelper2.createAndSignInUser(AuthenticationTest.class, true);
+        authApi = testUser.getClient(AuthenticationApi.class);
+    }
+    
+    @AfterClass
+    public static void afterClass() {
+        testUser.signOutAndDeleteUser();
+    }
+    
     @Test
-    public void canResendEmailVerification() {
-        // Just verify this doesn't throw an exception
-        ClientProvider.resendEmailVerification(
-                new EmailCredentials(Tests.TEST_KEY, "bridge-testing@sagebase.org"));
+    public void canResendEmailVerification() throws IOException {
+        Email email = new Email().study(testUser.getSignIn().getStudy())
+                .email(testUser.getSignIn().getEmail());
+        
+        authApi.resendEmailVerification(email).execute();
     }
     
     @Test
     public void resendingEmailVerificationToUnknownEmailDoesNotThrowException() throws Exception {
-        ClientProvider.resendEmailVerification(new EmailCredentials(Tests.TEST_KEY, "fooboo-sagebridge@antwerp.com"));
+        Email email = new Email().study(testUser.getStudyId()).email("bridge-testing@sagebase.org");
+        
+        authApi.resendEmailVerification(email).execute();
     }
     
     @Test
     public void requestingResetPasswordForUnknownEmailDoesNotThrowException() throws Exception {
-        ClientProvider.requestResetPassword(new EmailCredentials(Tests.TEST_KEY, "fooboo-sagebridge@antwerp.com"));
+        Email email = new Email().study(testUser.getStudyId()).email("fooboo-sagebridge@antwerp.com");
+        
+        authApi.requestResetPassword(email).execute();
     }
     
     @Test
-    public void accountWithOneStudySeparateFromAccountWithSecondStudy() {
-        TestUser testUser1 = TestUserHelper.createAndSignInUser(AuthenticationTest.class, true);
-        Config config = ClientProvider.getConfig();
-        StudyClient studyClient = ClientProvider.signIn(config.getAdminCredentials()).getStudyClient();
+    public void accountWithOneStudySeparateFromAccountWithSecondStudy() throws IOException {
+        TestUser adminUser = TestUserHelper2.getSignedInAdmin();
+        ForAdminsApi adminsApi = adminUser.getClient(ForAdminsApi.class);
         String studyId = Tests.randomIdentifier(AuthenticationTest.class);
-
-        // Make a second study for this test:
-        Study study = new Study();
-        study.setIdentifier(studyId);
-        study.setName("Second Study");
-        study.setSponsorName("Second Study");
-        study.setSupportEmail("bridge-testing+support@sagebase.org");
-        study.setConsentNotificationEmail("bridge-testing+consent@sagebase.org");
-        study.setTechnicalEmail("bridge-testing+technical@sagebase.org");
-        study.setResetPasswordTemplate(Tests.TEST_RESET_PASSWORD_TEMPLATE);
-        study.setVerifyEmailTemplate(Tests.TEST_VERIFY_EMAIL_TEMPLATE);
-        studyClient.createStudy(study);
-
         try {
+            testUser.signInAgain();
+
+            // Make a second study for this test:
+            Study study = new Study();
+            study.setIdentifier(studyId);
+            study.setName("Second Study");
+            study.setSponsorName("Second Study");
+            study.setSupportEmail("bridge-testing+support@sagebase.org");
+            study.setConsentNotificationEmail("bridge-testing+consent@sagebase.org");
+            study.setTechnicalEmail("bridge-testing+technical@sagebase.org");
+            study.setResetPasswordTemplate(Tests.TEST_RESET_PASSWORD_TEMPLATE);
+            study.setVerifyEmailTemplate(Tests.TEST_VERIFY_EMAIL_TEMPLATE);
+            
+            adminsApi.createStudy(study).execute();
+
             // Can we sign in to secondstudy? No.
             try {
-                config.set(Props.STUDY_IDENTIFIER, studyId);
-                ClientProvider.signIn(new SignInCredentials(studyId, testUser1.getEmail(), testUser1.getPassword()));
+                SignIn otherStudySignIn = new SignIn().study(studyId).email(testUser.getEmail()).password(testUser.getPassword());
+                ClientManager otherStudyManager = new ClientManager.Builder().withSignIn(otherStudySignIn).build();
+                
+                AuthenticationApi authClient = otherStudyManager.getClient(AuthenticationApi.class);
+                
+                authClient.signIn(otherStudySignIn).execute();
                 fail("Should not have allowed sign in");
-            } catch(BridgeSDKException e) {
+            } catch(EntityNotFoundException e) {
                 assertEquals(404, e.getStatusCode());
             }
         } finally {
-            config.set(Props.STUDY_IDENTIFIER, "api");
-            studyClient.deleteStudy(studyId);
-            testUser1.signOutAndDeleteUser();
+            adminsApi.deleteStudy(studyId).execute();
         }
     }
     
     // BRIDGE-465. We can at least verify that it gets processed as an error.
     @Test
     public void emailVerificationThrowsTheCorrectError() throws Exception {
-        Config config = ClientProvider.getConfig();
+        Config config = testUser.getClientManager().getConfig();
         
         HttpResponse response = Request
             .Post(config.getEnvironment().getUrl() + "/api/v1/auth/verifyEmail?study=api")
@@ -91,15 +117,18 @@ public class AuthenticationTest {
     // Should not be able to tell from the sign up response if an email is enrolled in the study or not.
     // Server change is not yet checked in for this.
     @Test
-    public void secondTimeSignUpLooksTheSameAsFirstTimeSignUp() {
-        TestUser testUser = TestUserHelper.createAndSignInUser(AuthenticationTest.class, true);
+    public void secondTimeSignUpLooksTheSameAsFirstTimeSignUp() throws IOException {
+        TestUser testUser = TestUserHelper2.createAndSignInUser(AuthenticationTest.class, true);
         try {
-            testUser.getSession().signOut();
+            testUser.signOut();
             
-            // Now create the same user.
-            StudyParticipant participant = new StudyParticipant.Builder()
-                    .withEmail(testUser.getEmail()).withPassword(testUser.getPassword()).build();
-            ClientProvider.signUp(Tests.TEST_KEY, participant);
+            // Now create the same user in terms of a sign up (same email).
+            SignUp signUp = new SignUp().study(testUser.getStudyId()).email(testUser.getEmail())
+                    .password(testUser.getPassword());
+            
+            // This should not throw an exception.
+            AuthenticationApi authApi = testUser.getClient(AuthenticationApi.class);
+            authApi.signUp(signUp).execute();
             
         } finally {
             testUser.signOutAndDeleteUser();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ConsentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ConsentTest.java
@@ -229,8 +229,6 @@ public class ConsentTest {
             assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, session.getSharingScope());
             assertTrue(Utilities.isUserConsented(session));
 
-            testUser = new TestUserHelper2.TestUser(session);
-
             // withdraw consent
             Withdrawal withdrawal = new Withdrawal().reason("Withdrawing test user from study");
             userApi = testUser.getAuthenticatedClient(ForConsentedUsersApi.class);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ExternalIdsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ExternalIdsTest.java
@@ -49,7 +49,7 @@ public class ExternalIdsTest {
         for (int i=0; i < LIST_SIZE; i++) {
             identifiers.add(prefix+RandomStringUtils.randomAlphabetic(10));
         }
-        ExternalIdentifiersApi externalIdsClient = developer.getAuthenticatedClient(ExternalIdentifiersApi.class);
+        ExternalIdentifiersApi externalIdsClient = developer.getClient(ExternalIdentifiersApi.class);
         externalIdsClient.addExternalIds(identifiers).execute();
         try {
             PagedResourceListExternalIdentifier page1 = externalIdsClient.getExternalIds(null, PAGE_SIZE, prefix, null)

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 import org.junit.After;
@@ -39,9 +38,7 @@ import org.sagebionetworks.bridge.sdk.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.sdk.models.upload.Upload;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadRequest;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadSession;
-import org.sagebionetworks.bridge.sdk.rest.model.AbstractStudyParticipant;
 
-import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -70,18 +67,19 @@ public class ParticipantsTest {
         try {
             UserClient userClient = user.getSession().getUserClient();
             
-            org.sagebionetworks.bridge.sdk.rest.model.StudyParticipant self = userClient.getStudyParticipant();
+            StudyParticipant self = userClient.getStudyParticipant();
             assertEquals(user.getEmail(), self.getEmail());
 
             // Update and verify changes. Right now there's not a lot that can be changed
-
-            org.sagebionetworks.bridge.sdk.rest.model.StudyParticipant updates = new org
-                    .sagebionetworks.bridge.sdk.rest.model.StudyParticipant();
-            updates
-                    .languages(Arrays.asList("nl", "en"))
-                    .dataGroups(Arrays.asList("group1")).notifyByEmail(false).sharingScope(
-                            AbstractStudyParticipant.SharingScopeEnum.ALL_QUALIFIED_RESEARCHERS);
-
+            LinkedHashSet<String> set = new LinkedHashSet<>();
+            set.add("nl");
+            set.add("en");
+            
+            StudyParticipant updates = new StudyParticipant.Builder()
+                    .withLanguages(set)
+                    .withDataGroups(Sets.newHashSet("group1"))
+                    .withNotifyByEmail(false)
+                    .withSharingScope(SharingScope.ALL_QUALIFIED_RESEARCHERS).build();
 
             userClient.saveStudyParticipant(updates);
             assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, user.getSession().getStudyParticipant().getSharingScope());

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SchedulePlanTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SchedulePlanTest.java
@@ -37,7 +37,7 @@ import org.sagebionetworks.bridge.sdk.models.schedules.SurveyReference;
 import org.sagebionetworks.bridge.sdk.models.schedules.TaskReference;
 import org.sagebionetworks.bridge.sdk.models.studies.OperatingSystem;
 import org.sagebionetworks.bridge.sdk.models.surveys.Survey;
-import org.sagebionetworks.bridge.sdk.utils.Utilities;
+import org.sagebionetworks.bridge.sdk.utils.BridgeUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -45,7 +45,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class SchedulePlanTest {
 
-    private static final ObjectMapper MAPPER = Utilities.getMapper();
+    private static final ObjectMapper MAPPER = BridgeUtils.getMapper();
 
     private TestUser admin;
     private TestUser user;

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduleTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduleTest.java
@@ -90,6 +90,7 @@ public class ScheduleTest {
     }
     
     @Test
+    @SuppressWarnings("deprecation")
     public void persistentSchedulePlanMarkedPersistent() throws Exception {
         SchedulePlan plan = Tests.getPersistentSchedulePlan();
         SchedulePlanClient schedulePlanClient = developer.getSession().getSchedulePlanClient();
@@ -104,6 +105,7 @@ public class ScheduleTest {
     }
     
     @Test
+    @SuppressWarnings("deprecation")
     public void simpleSchedulePlanNotMarkedPersistent() throws Exception {
         SchedulePlan plan = Tests.getSimpleSchedulePlan();
         SchedulePlanClient schedulePlanClient = developer.getSession().getSchedulePlanClient();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SessionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SessionTest.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -22,9 +21,7 @@ import org.sagebionetworks.bridge.sdk.integration.TestUserHelper.TestUser;
 import org.sagebionetworks.bridge.sdk.models.accounts.AccountStatus;
 import org.sagebionetworks.bridge.sdk.models.accounts.SharingScope;
 import org.sagebionetworks.bridge.sdk.models.accounts.StudyParticipant;
-import org.sagebionetworks.bridge.sdk.rest.model.AbstractStudyParticipant;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 public class SessionTest {
@@ -43,19 +40,19 @@ public class SessionTest {
             languages.add("fr");
             
             StudyParticipant participant = user.getSession().getStudyParticipant();
-            org.sagebionetworks.bridge.sdk.rest.model.StudyParticipant updated = new org
-                    .sagebionetworks.bridge.sdk.rest.model.StudyParticipant();
-
-                    updated.firstName("TestFirstName")
-                           .externalId("an_external_id")
-                           .dataGroups(Arrays.asList(dataGroups.toArray(new String[0])))
-                           .notifyByEmail(false)
-
-                           .status(AbstractStudyParticipant.StatusEnum.DISABLED)
-                           .sharingScope(AbstractStudyParticipant.SharingScopeEnum.SPONSORS_AND_PARTNERS)
-                           .roles(Lists.newArrayList(AbstractStudyParticipant.RolesEnum.ADMIN))
-                    .lastName("TestLastName")
-                    .languages(Arrays.asList(languages.toArray(new String[0])));
+            
+            StudyParticipant updated = new StudyParticipant.Builder()
+                    .copyOf(participant)
+                    .withFirstName("TestFirstName")
+                    .withExternalId("an_external_id")
+                    .withDataGroups(Sets.newHashSet(dataGroups.iterator().next()))
+                    .withNotifyByEmail(false)
+                    .withStatus(AccountStatus.DISABLED)
+                    .withSharingScope(SharingScope.SPONSORS_AND_PARTNERS)
+                    .withRoles(roles)
+                    .withLastName("TestLastName")
+                    .withLanguages(Tests.newLinkedHashSet("de"))
+                    .build();
             
             user.getSession().getUserClient().saveStudyParticipant(updated);
             
@@ -63,7 +60,7 @@ public class SessionTest {
             
             assertEquals("TestFirstName", asUpdated.getFirstName());
             assertEquals("TestLastName", asUpdated.getLastName());
-            assertEquals(languages, asUpdated.getLanguages());
+            assertEquals(Tests.newLinkedHashSet("de"), asUpdated.getLanguages());
             assertEquals(dataGroups, asUpdated.getDataGroups());
             assertEquals("an_external_id", asUpdated.getExternalId());
             assertFalse(asUpdated.isNotifyByEmail());

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignInTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignInTest.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.bridge.sdk.integration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
@@ -53,9 +52,8 @@ public class SignInTest {
         Set<String> dataGroups = Sets.newHashSet("sdk-int-1");
         UserClient userClient = user.getSession().getUserClient();
 
-        org.sagebionetworks.bridge.sdk.rest.model.StudyParticipant participant = new org
-                .sagebionetworks.bridge.sdk.rest.model.StudyParticipant();
-        participant.dataGroups(Lists.newArrayList(dataGroups));
+        StudyParticipant participant = new StudyParticipant.Builder()
+                .withDataGroups(Sets.newHashSet(dataGroups)).build();
         userClient.saveStudyParticipant(participant);
         
         user.getSession().signOut();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/TestUserHelper2.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/TestUserHelper2.java
@@ -1,0 +1,155 @@
+package org.sagebionetworks.bridge.sdk.integration;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.sagebionetworks.bridge.sdk.ClientManager;
+import org.sagebionetworks.bridge.sdk.rest.api.AuthenticationApi;
+import org.sagebionetworks.bridge.sdk.rest.api.ForAdminsApi;
+import org.sagebionetworks.bridge.sdk.rest.exceptions.BridgeSDKException;
+import org.sagebionetworks.bridge.sdk.rest.exceptions.ConsentRequiredException;
+import org.sagebionetworks.bridge.sdk.rest.model.EmptyPayload;
+import org.sagebionetworks.bridge.sdk.rest.model.Role;
+import org.sagebionetworks.bridge.sdk.rest.model.SignIn;
+import org.sagebionetworks.bridge.sdk.rest.model.SignUp;
+import org.sagebionetworks.bridge.sdk.rest.model.UserSessionInfo;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+public class TestUserHelper2 {
+
+    private static final ClientManager MANAGER = new ClientManager();
+    private static final EmptyPayload EMPTY_PAYLOAD = new EmptyPayload();
+    private static final String PASSWORD = "P4ssword";
+    
+    public static class TestUser {
+        private UserSessionInfo userSession;
+
+        public TestUser(UserSessionInfo session) {
+            this.userSession = session;
+        }
+        public UserSessionInfo getSession() {
+            return userSession;
+        }
+        public String getEmail() {
+            return userSession.getEmail();
+        }
+        public String getPassword() {
+            return PASSWORD;
+        }
+        public List<Role> getRoles() {
+            return userSession.getRoles();
+        }
+        public String getDefaultSubpopulation() {
+            return Tests.TEST_KEY;
+        }
+        public final <T> T getAuthenticatedClient(Class<T> service) {
+            return MANAGER.getAuthenticatedClient(service, getSignIn());
+        }
+        public UserSessionInfo signInAgain() {
+            AuthenticationApi authApi = MANAGER.getUnauthenticatedClient(AuthenticationApi.class);
+            try {
+                userSession = authApi.signIn(getSignIn()).execute().body();
+            } catch (ConsentRequiredException e) {
+                userSession = e.getSession();
+                throw e;
+            } catch(IOException ioe) {
+                throw new BridgeSDKException(ioe.getMessage(), ioe);
+            }
+            return userSession;
+        }
+        public void signOut() {
+            AuthenticationApi authApi = MANAGER.getAuthenticatedClient(AuthenticationApi.class, getSignIn());
+            authApi.signOut(EMPTY_PAYLOAD);
+            userSession.setAuthenticated(false);
+        }
+        public void signOutAndDeleteUser() {
+            this.signOut();
+
+            ForAdminsApi adminsApi = MANAGER.getAuthenticatedClient(ForAdminsApi.class,
+                    MANAGER.getConfig().getAdminSignIn());
+            adminsApi.deleteUser(userSession.getId());
+        }
+        public SignIn getSignIn() {
+            return new SignIn().study(Tests.TEST_KEY).email(userSession.getEmail()).password(PASSWORD);
+        }
+    }
+    public static TestUser getSignedInAdmin() {
+        SignIn authSignIn = MANAGER.getConfig().getAdminSignIn();
+        AuthenticationApi authApi = MANAGER.getUnauthenticatedClient(AuthenticationApi.class);
+        try {
+            UserSessionInfo session = authApi.signIn(authSignIn).execute().body();
+            return new TestUser(session);
+        } catch(IOException ioe) {
+            throw new BridgeSDKException(ioe.getMessage(), ioe);
+        }
+    }
+    public static TestUser createAndSignInUser(Class<?> cls, boolean consentUser, Role... roles) throws IOException {
+        SignUp signUp = new SignUp();
+        List<Role> rolesList = Lists.newArrayList();
+        if (roles != null) {
+            for (Role role : roles) {
+                rolesList.add(role);
+            }
+        }
+        signUp.setRoles(rolesList);
+        
+        return createAndSignInUser(cls, consentUser, signUp);
+    }
+    public static TestUser createAndSignInUser(Class<?> cls, boolean consentUser, SignUp signUp) throws IOException {
+        checkNotNull(cls);
+        
+        ForAdminsApi adminsApi = MANAGER.getAuthenticatedClient(ForAdminsApi.class,
+                MANAGER.getConfig().getAdminSignIn());
+
+        Set<Role> rolesList = Sets.newHashSet();
+        if (signUp != null && signUp.getRoles() != null) {
+            rolesList.addAll(signUp.getRoles());
+        }
+
+        // For email address, we don't want consent emails to bounce or SES will get mad at us. All test user email
+        // addresses should be in the form bridge-testing+[semi-unique token]@sagebase.org. This directs all test
+        // email to bridge-testing@sagebase.org.
+        String emailAddress = Tests.makeEmail(cls);
+
+        if (signUp == null) {
+            signUp = new SignUp();
+        }
+        if (signUp.getEmail() == null) {
+            signUp.email(emailAddress);    
+        }
+        signUp.setRoles(new ArrayList<>(rolesList));
+        signUp.setPassword(PASSWORD);
+        signUp.setConsent(consentUser);
+        adminsApi.createUser(signUp).execute().body();
+
+        SignIn signIn = new SignIn().study(Tests.TEST_KEY).email(emailAddress).password(PASSWORD);
+        UserSessionInfo userSession = null;
+        try {
+            try {
+                AuthenticationApi authApi = MANAGER.getAuthenticatedClient(AuthenticationApi.class, signIn);
+                userSession = authApi.signIn(signIn).execute().body();
+                //AuthenticationApi authApi = MANAGER.getUnauthenticatedClient(AuthenticationApi.class);
+                //userSession = authApi.signIn(signIn).execute().body();
+            } catch (ConsentRequiredException e) {
+                userSession = e.getSession();
+                if (consentUser) {
+                    // If there's no consent but we're expecting one, that's an error.
+                    throw e;
+                }
+            }
+            return new TestUser(userSession);
+        } catch (RuntimeException ex) {
+            // Clean up the account, so we don't end up with a bunch of leftover accounts.
+            if (userSession != null) {
+                adminsApi.deleteUser(userSession.getId());
+            }
+            throw new BridgeSDKException(ex.getMessage(), ex);
+        }
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
@@ -19,9 +19,10 @@ import org.sagebionetworks.bridge.sdk.models.schedules.SchedulePlan;
 import org.sagebionetworks.bridge.sdk.models.schedules.ScheduleType;
 import org.sagebionetworks.bridge.sdk.models.schedules.SimpleScheduleStrategy;
 import org.sagebionetworks.bridge.sdk.models.schedules.TaskReference;
-import org.sagebionetworks.bridge.sdk.models.studies.EmailTemplate;
 import org.sagebionetworks.bridge.sdk.models.studies.OperatingSystem;
 import org.sagebionetworks.bridge.sdk.models.studies.Study;
+import org.sagebionetworks.bridge.sdk.rest.model.EmailTemplate;
+import org.sagebionetworks.bridge.sdk.rest.model.MimeType;
 
 import com.google.common.collect.Sets;
 
@@ -33,11 +34,18 @@ public class Tests {
     
     public static final String TEST_KEY = "api";
     
-    public static final EmailTemplate TEST_RESET_PASSWORD_TEMPLATE = new EmailTemplate("Reset your password",
-            "<p>${url}</p>", EmailTemplate.MimeType.HTML);
-    public static final EmailTemplate TEST_VERIFY_EMAIL_TEMPLATE = new EmailTemplate("Verify your email",
-            "<p>${url}</p>", EmailTemplate.MimeType.HTML);
+    public static final EmailTemplate TEST_RESET_PASSWORD_TEMPLATE = new EmailTemplate().subject("Reset your password")
+        .body("<p>${url}</p>").mimeType(MimeType.TEXT_HTML);
+    public static final EmailTemplate TEST_VERIFY_EMAIL_TEMPLATE = new EmailTemplate().subject("Verify your email")
+        .body("<p>${url}</p>").mimeType(MimeType.TEXT_HTML);
 
+    public static final org.sagebionetworks.bridge.sdk.models.studies.EmailTemplate TEST_RESET_PASSWORD_TEMPLATE_OLD = new org.sagebionetworks.bridge.sdk.models.studies.EmailTemplate(
+            "Reset your password", "<p>${url}</p>",
+            org.sagebionetworks.bridge.sdk.models.studies.EmailTemplate.MimeType.HTML);
+    public static final org.sagebionetworks.bridge.sdk.models.studies.EmailTemplate TEST_VERIFY_EMAIL_TEMPLATE_OLD = new org.sagebionetworks.bridge.sdk.models.studies.EmailTemplate(
+            "Verify your email", "<p>${url}</p>",
+            org.sagebionetworks.bridge.sdk.models.studies.EmailTemplate.MimeType.HTML);
+        
     public static String randomIdentifier(Class<?> cls) {
         return ("sdk-" + cls.getSimpleName().toLowerCase() + "-" + RandomStringUtils.randomAlphabetic(5)).toLowerCase();
     }
@@ -151,8 +159,8 @@ public class Tests {
         study.getUserProfileAttributes().add("new_profile_attribute");
         study.setTaskIdentifiers(Sets.newHashSet("taskA")); // setting it differently just for the heck of it 
         study.setDataGroups(Sets.newHashSet("beta_users", "production_users"));
-        study.setResetPasswordTemplate(Tests.TEST_RESET_PASSWORD_TEMPLATE);
-        study.setVerifyEmailTemplate(Tests.TEST_VERIFY_EMAIL_TEMPLATE);
+        study.setResetPasswordTemplate(Tests.TEST_RESET_PASSWORD_TEMPLATE_OLD);
+        study.setVerifyEmailTemplate(Tests.TEST_VERIFY_EMAIL_TEMPLATE_OLD);
         study.setHealthCodeExportEnabled(true);
         study.getMinSupportedAppVersions().put(OperatingSystem.ANDROID, 10);
         study.getMinSupportedAppVersions().put(OperatingSystem.IOS, 14);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UTF8Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UTF8Test.java
@@ -30,8 +30,8 @@ public class UTF8Test {
         study.setTechnicalEmail("bridge-testing+technical@sagebase.org");
         study.setSupportEmail("bridge-testing+support@sagebase.org");
         study.setConsentNotificationEmail("bridge-testing+consent@sagebase.org");
-        study.setResetPasswordTemplate(Tests.TEST_RESET_PASSWORD_TEMPLATE);
-        study.setVerifyEmailTemplate(Tests.TEST_VERIFY_EMAIL_TEMPLATE);
+        study.setResetPasswordTemplate(Tests.TEST_RESET_PASSWORD_TEMPLATE_OLD);
+        study.setVerifyEmailTemplate(Tests.TEST_VERIFY_EMAIL_TEMPLATE_OLD);
 
         // create study
         studyClient.createStudy(study);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UTF8Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UTF8Test.java
@@ -11,8 +11,8 @@ import org.sagebionetworks.bridge.sdk.StudyClient;
 import org.sagebionetworks.bridge.sdk.UserClient;
 import org.sagebionetworks.bridge.sdk.integration.TestUserHelper.TestUser;
 import org.sagebionetworks.bridge.sdk.models.accounts.SignInCredentials;
+import org.sagebionetworks.bridge.sdk.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.sdk.models.studies.Study;
-import org.sagebionetworks.bridge.sdk.rest.model.StudyParticipant;
 
 @Category(IntegrationSmokeTest.class)
 public class UTF8Test {
@@ -53,10 +53,9 @@ public class UTF8Test {
         try {
             UserClient userClient = testUser.getSession().getUserClient();
 
-           StudyParticipant participant = new StudyParticipant();
-            participant.firstName("☃");
-            // I understand from the source of this text that it is actually UTF-16. It should still work.
-            participant.lastName("지구상의　３대　극지라　불리는");
+           StudyParticipant participant = new StudyParticipant.Builder()
+                   .withFirstName("☃")
+                   .withLastName("지구상의　３대　극지라　불리는").build();
 
             userClient.saveStudyParticipant(participant);
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -7,7 +7,7 @@
     </encoder>
   </appender>
 
-  <logger name="org.sagebionetworks.bridge.sdk.BaseApiCaller" level="warn" />
+  <logger name="org.sagebionetworks.bridge.sdk" level="warn" />
 
   <root level="info">
     <appender-ref ref="STDOUT" />


### PR DESCRIPTION
Based on the api-codegen classes as of 0.11.3 SDK.
- ConsentTest migrated
- ExternalIdsTest migrated

Other tests _undo_ changes that were made to integrate the api-codegen classes into the existing Java SDK files. In order to migrate one test at a time, I've undone these changes in favor of working with a parallel set of classes. Once everything has been migrated, we'll delete the old stuff, do any moves or renames necessary to clean up.
