### PR TITLE
pull in new JavaSDK with new timeouts, to fix Devo integ tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.12.4</version>
+            <version>0.12.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Pulls in https://github.com/Sage-Bionetworks/BridgeJavaSDK/pull/343 to fix Devo integ tests