### PR TITLE
Updating to 0.12.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.12.6</version>
+            <version>0.12.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/resources/bridge-sdk.properties
+++ b/src/test/resources/bridge-sdk.properties
@@ -1,2 +1,0 @@
-log.level = warn
-sdk.version = 5


### PR DESCRIPTION
And removing the bridge-sdk.properties file that is the de facto default settings. These should be in the rest-client.jar, not the integration tests. That has been fixed.