### PR TITLE
pull SchemaType changes and other breaking changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.12.8</version>
+            <version>0.12.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
@@ -111,7 +111,7 @@ public class ParticipantsTest {
     public void canRetrieveAndPageThroughParticipants() throws Exception {
         ParticipantsApi participantsApi = researcher.getClient(ParticipantsApi.class);
         
-        AccountSummaryList summaries = participantsApi.getParticipants(0, 10, null).execute().body();
+        AccountSummaryList summaries = participantsApi.getParticipants(0, 10, null, null, null).execute().body();
 
         // Well we know there's at least two accounts... the admin and the researcher.
         assertEquals((Long)0L, summaries.getOffsetBy());
@@ -127,7 +127,7 @@ public class ParticipantsTest {
         
         // Filter to only the researcher
         
-        summaries = participantsApi.getParticipants(0, 10, researcher.getEmail()).execute().body();
+        summaries = participantsApi.getParticipants(0, 10, researcher.getEmail(), null, null).execute().body();
         assertEquals(1, summaries.getItems().size());
         assertEquals(researcher.getEmail(), summaries.getItems().get(0).getEmail());
         assertEquals(researcher.getEmail(), summaries.getEmailFilter()/*getFilters().get("emailFilter")*/);
@@ -137,14 +137,14 @@ public class ParticipantsTest {
     public void cannotSetBadOffset() throws Exception {
         ParticipantsApi participantsApi = researcher.getClient(ParticipantsApi.class);
         
-        participantsApi.getParticipants(-1, 10, null).execute();
+        participantsApi.getParticipants(-1, 10, null, null, null).execute();
     }
     
     @Test(expected = BadRequestException.class)
     public void cannotSetBadPageSize() throws Exception {
         ParticipantsApi participantsApi = researcher.getClient(ParticipantsApi.class);
         
-        participantsApi.getParticipants(0, 4, null).execute();
+        participantsApi.getParticipants(0, 4, null, null, null).execute();
     }
     
     @Test
@@ -176,7 +176,7 @@ public class ParticipantsTest {
             // It has been persisted. Right now we don't get the ID back so we have to conduct a 
             // search by email to get this user.
             // Can be found through paged results
-            AccountSummaryList search = participantsApi.getParticipants(0,  10, email).execute().body();
+            AccountSummaryList search = participantsApi.getParticipants(0, 10, email, null, null).execute().body();
             assertEquals((Integer)1, search.getTotal());
             AccountSummary summary = search.getItems().get(0);
             assertEquals("FirstName", summary.getFirstName());

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignInTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignInTest.java
@@ -91,7 +91,8 @@ public class SignInTest {
 
         ParticipantsApi participantsApi = researcher.getClient(ParticipantsApi.class);
         
-        AccountSummaryList summaries = participantsApi.getParticipants(0, 10, signUp.getEmail()).execute().body();
+        AccountSummaryList summaries = participantsApi.getParticipants(0, 10, signUp.getEmail(), null, null).execute()
+                .body();
         assertEquals(1, summaries.getItems().size());
         
         AccountSummary summary = summaries.getItems().get(0);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyTest.java
@@ -217,7 +217,7 @@ public class StudyTest {
             UploadsApi devUploadsApi = developer.getClient(UploadsApi.class);
             DateTime startTime = DateTime.now(DateTimeZone.UTC).minusHours(2);
             DateTime endTime = startTime.plusHours(4);
-            int count = devUploadsApi.getStudyUploads(startTime, endTime).execute().body().getItems().size();
+            int count = devUploadsApi.getUploads(startTime, endTime).execute().body().getItems().size();
 
             // Create a REQUESTED record that we can retrieve through the reporting API.
             UploadRequest request = new UploadRequest();
@@ -235,7 +235,7 @@ public class StudyTest {
             
             // This should retrieve both of the user's uploads.
             StudiesApi studiesApi = developer.getClient(StudiesApi.class);
-            UploadList results = studiesApi.getStudyUploads(startTime, endTime).execute().body();
+            UploadList results = studiesApi.getUploads(startTime, endTime).execute().body();
             assertEquals(startTime, results.getStartTime());
             assertEquals(endTime, results.getEndTime());
 

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveySchemaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveySchemaTest.java
@@ -341,7 +341,7 @@ public class SurveySchemaTest {
     private void validateCommonSchemaProperties(UploadSchema schema, GuidCreatedOnVersionHolder surveyKeys) {
         assertEquals(SURVEY_NAME, schema.getName());
         assertEquals(surveyId, schema.getSchemaId());
-        assertEquals(UploadSchemaType.SURVEY, schema.getSchemaType());
+        assertEquals(UploadSchemaType.IOS_SURVEY, schema.getSchemaType());
         assertEquals(surveyKeys.getGuid(), schema.getSurveyGuid());
         assertEquals(surveyKeys.getCreatedOn(), schema.getSurveyCreatedOn());
     }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
@@ -95,11 +95,13 @@ public class UploadSchemaTest {
         UploadFieldDefinition bazFieldDef = field("baz", true, UploadFieldType.BOOLEAN);
 
         // Step 1: Create initial version of schema.
-        UploadSchema schemaV1 = schema(null, "Upload Schema Integration Tests", schemaId, UploadSchemaType.DATA, fooFieldDef);
+        UploadSchema schemaV1 = schema(null, "Upload Schema Integration Tests", schemaId, UploadSchemaType.IOS_DATA,
+                fooFieldDef);
         UploadSchema createdSchemaV1 = createOrUpdateSchemaAndVerify(schemaV1);
 
         // Step 2: Update to v2
-        UploadSchema schemaV2 = schema(createdSchemaV1, "Schema Test II: The Sequel", schemaId, UploadSchemaType.DATA, fooFieldDef, barFieldDef);
+        UploadSchema schemaV2 = schema(createdSchemaV1, "Schema Test II: The Sequel", schemaId,
+                UploadSchemaType.IOS_DATA, fooFieldDef, barFieldDef);
         UploadSchema updatedSchemaV2 = createOrUpdateSchemaAndVerify(schemaV2);
 
         // Step 3: Another update. Having multiple versions helps test the delete API.
@@ -221,7 +223,7 @@ public class UploadSchemaTest {
         def4.setUnboundedText(true);
         
         List<UploadFieldDefinition> fieldDefList = ImmutableList.of(def1, def2, def3, def4);
-        UploadSchema schema = schema("Schema", schemaId, UploadSchemaType.SURVEY, fieldDefList);
+        UploadSchema schema = schema("Schema", schemaId, UploadSchemaType.IOS_SURVEY, fieldDefList);
         schema.setSurveyGuid("survey");
         schema.setSurveyCreatedOn(surveyCreatedOn);
                 
@@ -231,7 +233,7 @@ public class UploadSchemaTest {
         assertEquals("Schema", createdSchema.getName());
         assertEquals(1, createdSchema.getRevision().intValue());
         assertEquals(schemaId, createdSchema.getSchemaId());
-        assertEquals(UploadSchemaType.SURVEY, createdSchema.getSchemaType());
+        assertEquals(UploadSchemaType.IOS_SURVEY, createdSchema.getSchemaType());
         assertNull(createdSchema.getStudyId());
         assertEquals("survey", createdSchema.getSurveyGuid());
         assertEquals(surveyCreatedOnMillis, createdSchema.getSurveyCreatedOn().getMillis());
@@ -288,7 +290,7 @@ public class UploadSchemaTest {
         schema.setName("Schema");
         schema.setSchemaId(schemaId);
         schema.setRevision(rev);
-        schema.setSchemaType(UploadSchemaType.DATA);
+        schema.setSchemaType(UploadSchemaType.IOS_DATA);
         schema.setFieldDefinitions(Lists.newArrayList(fieldDef));
         return schema;
     }
@@ -313,14 +315,14 @@ public class UploadSchemaTest {
         schemaV1.setName("Schema");
         schemaV1.setRevision(2L);
         schemaV1.setSchemaId(schemaId);
-        schemaV1.setSchemaType(UploadSchemaType.DATA);
+        schemaV1.setSchemaType(UploadSchemaType.IOS_DATA);
         schemaV1.setFieldDefinitions(fieldDefListV1);
         
         UploadSchema createdSchema = devUploadSchemasApi.createUploadSchema(schemaV1).execute().body();
         assertEquals("Schema", createdSchema.getName());
         assertEquals(2, createdSchema.getRevision().intValue());
         assertEquals(schemaId, createdSchema.getSchemaId());
-        assertEquals(UploadSchemaType.DATA, createdSchema.getSchemaType());
+        assertEquals(UploadSchemaType.IOS_DATA, createdSchema.getSchemaType());
         assertNull(createdSchema.getStudyId());
         assertEquals(fieldDefListV1, createdSchema.getFieldDefinitions());
 
@@ -372,7 +374,7 @@ public class UploadSchemaTest {
         assertEquals("Updated Schema", updatedSchema.getName());
         assertEquals(2, updatedSchema.getRevision().intValue());
         assertEquals(schemaId, updatedSchema.getSchemaId());
-        assertEquals(UploadSchemaType.DATA, updatedSchema.getSchemaType());
+        assertEquals(UploadSchemaType.IOS_DATA, updatedSchema.getSchemaType());
         assertNull(updatedSchema.getStudyId());
         assertEquals(fieldDefListV2, updatedSchema.getFieldDefinitions());
 

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadTest.java
@@ -79,7 +79,7 @@ public class UploadTest {
             legacySurveySchema.setSchemaId("legacy-survey");
             legacySurveySchema.setRevision(1L);
             legacySurveySchema.setName("Legacy (RK/AC) Survey");
-            legacySurveySchema.setSchemaType(UploadSchemaType.SURVEY);
+            legacySurveySchema.setSchemaType(UploadSchemaType.IOS_SURVEY);
             legacySurveySchema.setFieldDefinitions(Lists.newArrayList(def1,def2));
             uploadSchemasApi.createUploadSchema(legacySurveySchema).execute();
         }
@@ -114,7 +114,7 @@ public class UploadTest {
             legacyNonSurveySchema.setSchemaId("legacy-non-survey");
             legacyNonSurveySchema.setRevision(1L);
             legacyNonSurveySchema.setName("Legacy (RK/AC) Non-Survey");
-            legacyNonSurveySchema.setSchemaType(UploadSchemaType.DATA);
+            legacyNonSurveySchema.setSchemaType(UploadSchemaType.IOS_DATA);
             legacyNonSurveySchema.setFieldDefinitions(Lists.newArrayList(def1,def2,def3,def4,def5));
             uploadSchemasApi.createUploadSchema(legacyNonSurveySchema).execute();
         }


### PR DESCRIPTION
Updates JavaSDK and pulls the SchemaType changes. This also pulls in other previously unresolved breaking changes.

Tested against Staging.

Pre-req: https://github.com/Sage-Bionetworks/BridgeJavaSDK/pull/353