### PR TITLE
Tests to verify that default notifyByEmail value is true, and is not reset.

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
@@ -81,14 +81,16 @@ public class ParticipantsTest {
 
             self.setLanguages(set);
             self.setDataGroups(Lists.newArrayList("group1"));
-            self.setNotifyByEmail(false);
             self.setSharingScope(SharingScope.ALL_QUALIFIED_RESEARCHERS);
+            self.setNotifyByEmail(null); // BRIDGE-1604: should use default value: true
 
             userApi.updateUsersParticipantRecord(self).execute();
             
             self = userApi.getUsersParticipantRecord().execute().body();
             assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, self.getSharingScope());
             assertEquals(Lists.newArrayList("group1"), self.getDataGroups());
+            assertTrue(self.getNotifyByEmail());  // BRIDGE-1604: true value returned
+            
             // also language, but this hasn't been added to the session object yet.
         } finally {
             user.signOutAndDeleteUser();
@@ -162,7 +164,7 @@ public class ParticipantsTest {
         participant.setEmail(email);
         participant.setExternalId("externalID");
         participant.setSharingScope(SharingScope.ALL_QUALIFIED_RESEARCHERS);
-        participant.setNotifyByEmail(true);
+        // BRIDGE-1604: leave notifyByEmail to its default value (should be true)
         participant.setDataGroups(dataGroups);
         participant.setLanguages(languages);
         participant.setStatus(AccountStatus.DISABLED); // should be ignored
@@ -210,7 +212,7 @@ public class ParticipantsTest {
             newParticipant.setEmail(email);
             newParticipant.setExternalId("externalID2");
             newParticipant.setSharingScope(SharingScope.NO_SHARING);
-            newParticipant.setNotifyByEmail(false);
+            newParticipant.setNotifyByEmail(null);
             newParticipant.setDataGroups(newDataGroups);
             newParticipant.setLanguages(newLanguages);
             newParticipant.setAttributes(newAttributes);
@@ -228,7 +230,8 @@ public class ParticipantsTest {
             assertEquals(email, retrieved.getEmail());
             assertEquals("externalID2", retrieved.getExternalId());
             assertEquals(SharingScope.NO_SHARING, retrieved.getSharingScope());
-            assertFalse(retrieved.getNotifyByEmail());
+            // BRIDGE-1604: should still be true, even though it was not sent to the server. Through participants API 
+            assertTrue(retrieved.getNotifyByEmail());
             assertListsEqualIgnoringOrder(newDataGroups, retrieved.getDataGroups());
             assertListsEqualIgnoringOrder(newLanguages, retrieved.getLanguages());
             assertEquals(id, retrieved.getId());

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignUpTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignUpTest.java
@@ -11,16 +11,30 @@ import org.junit.Test;
 import org.sagebionetworks.bridge.sdk.integration.TestUserHelper.TestUser;
 import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
 import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
+import org.sagebionetworks.bridge.rest.api.ParticipantsApi;
 import org.sagebionetworks.bridge.rest.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.rest.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.rest.model.Email;
+import org.sagebionetworks.bridge.rest.model.SharingScope;
 import org.sagebionetworks.bridge.rest.model.SignIn;
 import org.sagebionetworks.bridge.rest.model.SignUp;
 import org.sagebionetworks.bridge.rest.model.Study;
+import org.sagebionetworks.bridge.rest.model.StudyParticipant;
 import org.sagebionetworks.bridge.rest.model.UserSessionInfo;
 
 public class SignUpTest {
 
+    @Test
+    public void defaultValuesExist() throws Exception {
+        TestUser testUser = TestUserHelper.createAndSignInUser(SignUpTest.class, true);
+        
+        ParticipantsApi participantsApi = testUser.getClientManager().getClient(ParticipantsApi.class);
+        
+        StudyParticipant participant = participantsApi.getUsersParticipantRecord().execute().body();
+        assertTrue(participant.getNotifyByEmail());
+        assertEquals(SharingScope.NO_SHARING, participant.getSharingScope());
+    }
+    
     @Test
     public void canAuthenticateAndCreateClientAndSignOut() throws IOException {
         TestUser testUser = TestUserHelper.createAndSignInUser(SignUpTest.class, true);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserParticipantTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserParticipantTest.java
@@ -80,10 +80,6 @@ public class UserParticipantTest {
             assertEquals("Last name updated", "Crockett2", participant.getLastName());
             assertEquals("true", participant.getAttributes().get("can_be_recontacted"));
             assertFalse(participant.getNotifyByEmail());
-            
-            participant.setNotifyByEmail(false);
-            participantsApi.updateUsersParticipantRecord(participant).execute().body();
-            participant = participantsApi.getUsersParticipantRecord().execute().body();
         } finally {
             user.signOutAndDeleteUser();
         }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserProfileTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserProfileTest.java
@@ -1,0 +1,73 @@
+package org.sagebionetworks.bridge.sdk.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.rest.api.ParticipantsApi;
+import org.sagebionetworks.bridge.rest.model.StudyParticipant;
+import org.sagebionetworks.bridge.sdk.integration.TestUserHelper.TestUser;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+/**
+ * The user profile APIs are deprecated, but still heavily in use. This verifies the APIs work and don't 
+ * change a property like notifyByEmail. There is no SDK support for this call.
+ */
+public class UserProfileTest {
+    
+    TestUser testUser;
+    
+    @Before
+    public void before() throws Exception {
+        testUser = TestUserHelper.createAndSignInUser(ParticipantsTest.class, true);
+    }
+    
+    @After
+    public void after() throws Exception {
+        if (testUser != null) {
+            testUser.signOutAndDeleteUser();
+        }
+    }
+    
+    @Test
+    public void canCrudUserProfileWithDeprecatedApi() throws Exception {
+        StudyParticipant newParticipant = new StudyParticipant();
+        newParticipant.setFirstName("FirstName2");
+        newParticipant.setLastName("LastName2");
+        newParticipant.setNotifyByEmail(null);
+        
+        JsonElement node = new Gson().toJsonTree(newParticipant);
+        node.getAsJsonObject().addProperty("phone", "206-555-1212");
+        String json = new Gson().toJson(node);
+        
+        Request request = new Request.Builder().url(testUser.getClientManager().getHostUrl() + "/v3/users/self")
+                .header("Bridge-Session", testUser.getSession().getSessionToken())
+                .method("POST", RequestBody.create(MediaType.parse("application/json"), json)).build();
+        
+        OkHttpClient client = new OkHttpClient();
+        Response response = client.newCall(request).execute();
+        assertEquals(200, response.code());
+        
+        // Now get the participant record and verify that notifyByEmail is true (the default)
+        ParticipantsApi participantsApi = testUser.getClient(ParticipantsApi.class);
+        
+        StudyParticipant participant = participantsApi.getUsersParticipantRecord().execute().body();
+        
+        assertEquals("FirstName2", participant.getFirstName());
+        assertEquals("LastName2", participant.getLastName());
+        assertTrue(participant.getNotifyByEmail()); // NOT CHANGED
+        assertEquals("206-555-1212", participant.getAttributes().get("phone"));
+    }
+    
+}


### PR DESCRIPTION
I see no cases now where this is getting set wrong with server fix, including sign up. So new users should have this set to true.