### PR TITLE
delete schema API is now an Admin API (only to be used by integ tests for test cleanup)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.12.13</version>
+            <version>0.12.15</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.12.15</version>
+            <version>0.12.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveySchemaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveySchemaTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.sdk.integration.TestUserHelper.TestUser;
 import org.sagebionetworks.bridge.rest.api.SurveysApi;
 import org.sagebionetworks.bridge.rest.api.UploadSchemasApi;
@@ -44,7 +45,8 @@ public class SurveySchemaTest {
 
     private static final String SURVEY_NAME = "Compatibility Test Survey";
 
-    private static TestUserHelper.TestUser developer;
+    private static TestUser admin;
+    private static TestUser developer;
     private static UploadSchemasApi schemasApi;
     private static SurveysApi surveysApi;
 
@@ -56,6 +58,7 @@ public class SurveySchemaTest {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
+        admin = TestUserHelper.getSignedInAdmin();
         developer = TestUserHelper.createAndSignInUser(UploadSchemaTest.class, false, Role.DEVELOPER);
         schemasApi = developer.getClient(UploadSchemasApi.class);
         surveysApi = developer.getClient(SurveysApi.class);
@@ -73,7 +76,6 @@ public class SurveySchemaTest {
     @After
     public void after() throws Exception {
         // cleanup surveys
-        TestUser admin = TestUserHelper.getSignedInAdmin();
         SurveysApi surveysApi = admin.getClient(SurveysApi.class);
         for (GuidCreatedOnVersionHolder oneSurvey : surveysToDelete) {
             try {
@@ -86,8 +88,9 @@ public class SurveySchemaTest {
 
     @After
     public void deleteSchemas() throws Exception {
+        ForAdminsApi adminApi = admin.getClient(ForAdminsApi.class);
         try {
-            schemasApi.deleteAllRevisionsOfUploadSchema(surveyId).execute();
+            adminApi.deleteAllRevisionsOfUploadSchema(Tests.TEST_KEY, surveyId).execute();
         } catch (EntityNotFoundException ex) {
             // Suppress the exception, as the test may have already deleted the schema.
         }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
@@ -6,7 +6,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -19,6 +21,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
 import org.sagebionetworks.bridge.rest.api.UploadSchemasApi;
 import org.sagebionetworks.bridge.rest.exceptions.ConcurrentModificationException;
@@ -38,6 +41,7 @@ public class UploadSchemaTest {
     private static TestUserHelper.TestUser developer;
     private static TestUserHelper.TestUser user;
     private static TestUserHelper.TestUser worker;
+    private static ForAdminsApi adminApi;
     private static UploadSchemasApi devUploadSchemasApi;
     private static ForWorkersApi workerUploadSchemasApi;
 
@@ -45,9 +49,12 @@ public class UploadSchemaTest {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
+        TestUserHelper.TestUser admin = TestUserHelper.getSignedInAdmin();
         developer = TestUserHelper.createAndSignInUser(UploadSchemaTest.class, false, Role.DEVELOPER);
         user = TestUserHelper.createAndSignInUser(UploadSchemaTest.class, true);
         worker = TestUserHelper.createAndSignInUser(UploadSchemaTest.class, false, Role.WORKER);
+
+        adminApi = admin.getClient(ForAdminsApi.class);
         devUploadSchemasApi = developer.getClient(UploadSchemasApi.class);
         workerUploadSchemasApi = worker.getClient(ForWorkersApi.class);
     }
@@ -60,7 +67,7 @@ public class UploadSchemaTest {
     @After
     public void deleteSchemas() throws Exception {
         try {
-            devUploadSchemasApi.deleteAllRevisionsOfUploadSchema(schemaId).execute();
+            adminApi.deleteAllRevisionsOfUploadSchema(Tests.TEST_KEY, schemaId).execute();
         } catch (EntityNotFoundException ex) {
             // Suppress the exception, as the test may have already deleted the schema.
         }
@@ -119,34 +126,22 @@ public class UploadSchemaTest {
         
         assertEquals(updatedSchemaV2, workerSchemaV2MinusStudyId);
 
-        // Step 4: Delete v3 and verify the getter returns v2.
-        devUploadSchemasApi.deleteUploadSchema(schemaId, 3L).execute();
-        UploadSchema returnedAfterDelete = devUploadSchemasApi.getMostRecentUploadSchema(schemaId).execute().body();
-        assertEquals(updatedSchemaV2, returnedAfterDelete);
-
-        // Step 4a: Use list API to verify v1 and v2 are both still present
-        boolean v1Found = false;
-        boolean v2Found = false;
+        // Step 4a: Use list API to verify all 3 versions are still present
+        Set<Long> foundRevSet = new HashSet<>();
         UploadSchemaList schemaList = devUploadSchemasApi.getAllRevisionsOfUploadSchema(schemaId).execute().body();
+        //noinspection Convert2streamapi
         for (UploadSchema oneSchema : schemaList.getItems()) {
             if (oneSchema.getSchemaId().equals(schemaId)) {
-                long rev = oneSchema.getRevision();
-                if (rev == 1) {
-                    assertEquals(createdSchemaV1, oneSchema);
-                    v1Found = true;
-                } else if (rev == 2) {
-                    assertEquals(updatedSchemaV2, oneSchema);
-                    v2Found = true;
-                } else {
-                    fail("Unexpected schema revision: " + rev);
-                }
+                foundRevSet.add(oneSchema.getRevision());
             }
         }
-        assertTrue(v1Found);
-        assertTrue(v2Found);
+        assertEquals(3, foundRevSet.size());
+        assertTrue(foundRevSet.contains(1L));
+        assertTrue(foundRevSet.contains(2L));
+        assertTrue(foundRevSet.contains(3L));
 
         // Step 5: Delete all schemas with the test schema ID
-        devUploadSchemasApi.deleteAllRevisionsOfUploadSchema(schemaId).execute();
+        adminApi.deleteAllRevisionsOfUploadSchema(Tests.TEST_KEY, schemaId).execute();
 
         // Step 5a: Get API should throw
         Exception thrownEx = null;


### PR DESCRIPTION
Note that this depends on the corresponding JavaSDK change.

See also:
* https://github.com/Sage-Bionetworks/BridgePF/pull/1313
* https://github.com/Sage-Bionetworks/BridgeJavaSDK/pull/357