### PR TITLE
Remove duplicate log4j impl, restore logback (and its configs)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,12 +57,6 @@
             <artifactId>synapseJavaClient</artifactId>
             <version>161.0-4-g843de2c</version>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.21</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <repositories>


### PR DESCRIPTION
* Remove slf4j-simple (bridge-base already brings in logback)

https://sagebionetworks.jira.com/browse/BRIDGE-1616

bridge-base brings in logback, so adding slf4j-simple was resulting in multiple implementations being bound