### PR TITLE
fix StudyTest, SignUpTest

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignUpTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignUpTest.java
@@ -26,12 +26,15 @@ public class SignUpTest {
     @Test
     public void defaultValuesExist() throws Exception {
         TestUser testUser = TestUserHelper.createAndSignInUser(SignUpTest.class, true);
-        
-        ParticipantsApi participantsApi = testUser.getClientManager().getClient(ParticipantsApi.class);
-        
-        StudyParticipant participant = participantsApi.getUsersParticipantRecord().execute().body();
-        assertTrue(participant.getNotifyByEmail());
-        assertEquals(SharingScope.NO_SHARING, participant.getSharingScope());
+        try {
+            ParticipantsApi participantsApi = testUser.getClientManager().getClient(ParticipantsApi.class);
+
+            StudyParticipant participant = participantsApi.getUsersParticipantRecord().execute().body();
+            assertTrue(participant.getNotifyByEmail());
+            assertEquals(SharingScope.NO_SHARING, participant.getSharingScope());
+        } finally {
+            testUser.signOutAndDeleteUser();
+        }
     }
     
     @Test


### PR DESCRIPTION
Changes:
* One test in SignUpTest wasn't cleaning up accounts.
* One test in StudyTest was using an admin account to call a Developer-only API.
* Nonsensical counts in one test in StudyTest.
* References to getTotal() for getStudyUploads() for StudyTest removed, as this value isn't particularly meaningful.
* Pagination tests for getStudyUploads() assume that the uploads created by the test are the only uploads. Removed this assumption. We already verify the uploads we're looking for in another part of the test.

Tested in both Prod (old code) and Staging (new code).