### PR TITLE
fix ScheduledActivityTest to function when there are other schedule plans in api study

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduledActivityTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduledActivityTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -38,10 +39,13 @@ public class ScheduledActivityTest {
     private TestUser user;
     private TestUser developer;
     private SchedulesApi schedulePlansApi;
+    private List<String> schedulePlanGuidList;
     private ForConsentedUsersApi usersApi;
 
     @Before
     public void before() throws Exception {
+        schedulePlanGuidList = new ArrayList<>();
+
         developer = TestUserHelper.createAndSignInUser(ScheduledActivityTest.class, true, Role.DEVELOPER);
         user = TestUserHelper.createAndSignInUser(ScheduledActivityTest.class, true);
 
@@ -70,7 +74,8 @@ public class ScheduledActivityTest {
         SchedulePlan plan = new SchedulePlan();
         plan.setLabel("Schedule plan 1");
         plan.setStrategy(strategy);
-        schedulePlansApi.createSchedulePlan(plan).execute();
+        String planGuid = schedulePlansApi.createSchedulePlan(plan).execute().body().getGuid();
+        schedulePlanGuidList.add(planGuid);
         
         // Add a schedule plan in the future... this should not effect any tests, *until* we request
         // a minimum number of tasks, which will retrieve this.
@@ -97,15 +102,15 @@ public class ScheduledActivityTest {
         plan = new SchedulePlan();
         plan.setLabel("Schedule plan 2");
         plan.setStrategy(strategy);
-        schedulePlansApi.createSchedulePlan(plan).execute();
+        planGuid = schedulePlansApi.createSchedulePlan(plan).execute().body().getGuid();
+        schedulePlanGuidList.add(planGuid);
     }
 
     @After
     public void after() throws Exception {
         try {
-            List<SchedulePlan> plans = schedulePlansApi.getSchedulePlans().execute().body().getItems();
-            for (SchedulePlan plan : plans) {
-                schedulePlansApi.deleteSchedulePlan(plan.getGuid()).execute();
+            for (String oneSchedulePlanGuid : schedulePlanGuidList) {
+                schedulePlansApi.deleteSchedulePlan(oneSchedulePlanGuid).execute();
             }
         } finally {
             if (developer != null) {
@@ -119,53 +124,74 @@ public class ScheduledActivityTest {
     
     @Test
     public void createSchedulePlanGetScheduledActivities() throws Exception {
+        // Get scheduled activities. Validate basic properties.
         ScheduledActivityList scheduledActivities = usersApi.getScheduledActivities("+00:00", 4, 0).execute().body();
-        
-        ScheduledActivity schActivity = scheduledActivities.getItems().get(0);
+        ScheduledActivity schActivity = findActivity1(scheduledActivities);
+        assertNotNull(schActivity);
         assertEquals(ScheduleStatus.SCHEDULED, schActivity.getStatus());
         assertNotNull(schActivity.getScheduledOn());
         assertNull(schActivity.getExpiresOn());
-        
+
         Activity activity = schActivity.getActivity();
         assertEquals(ActivityType.TASK, activity.getActivityType());
         assertEquals("Activity 1", activity.getLabel());
         assertEquals("task:AAA", activity.getTask().getIdentifier());
 
+        // Start the activity.
         schActivity.setStartedOn(DateTime.now());
         usersApi.updateScheduledActivities(scheduledActivities.getItems()).execute();
-        scheduledActivities = usersApi.getScheduledActivities("+00:00", 3, null).execute().body();
 
-        assertEquals((Integer)1, scheduledActivities.getTotal());
-        assertEquals(ScheduleStatus.STARTED, scheduledActivities.getItems().get(0).getStatus());
-        
-        schActivity = scheduledActivities.getItems().get(0);
+        // Get activities back and validate that it's started.
+        scheduledActivities = usersApi.getScheduledActivities("+00:00", 3, null).execute().body();
+        schActivity = findActivity1(scheduledActivities);
+        assertNotNull(schActivity);
+        assertEquals(ScheduleStatus.STARTED, schActivity.getStatus());
+
+        // Finish the activity.
         schActivity.setFinishedOn(DateTime.now());
         usersApi.updateScheduledActivities(scheduledActivities.getItems()).execute();
+
+        // Get activities back. Verify the activity is not there.
         scheduledActivities = usersApi.getScheduledActivities("+00:00", 3, null).execute().body();
-        assertEquals((Integer)0, scheduledActivities.getTotal()); // no activities == finished
+        schActivity = findActivity1(scheduledActivities);
+        assertNull(schActivity);
     }
-    
+
+    // api study may have other schedule plans in it with other scheduled activities. To prevent tests from
+    // conflicting, look for the activity with label "Activity 1".
+    private static ScheduledActivity findActivity1(ScheduledActivityList scheduledActivityList) {
+        for (ScheduledActivity oneScheduledActivity : scheduledActivityList.getItems()) {
+            if ("Activity 1".equals(oneScheduledActivity.getActivity().getLabel())) {
+                return oneScheduledActivity;
+            }
+        }
+
+        // It doesn't exist. Return null and let the test deal with it.
+        return null;
+    }
+
     @Test
     public void getScheduledActivitiesWithMinimumActivityValue() throws Exception {
         ScheduledActivityList scheduledActivities = usersApi.getScheduledActivities("+00:00", 4, 2).execute().body();
         
-        Multiset<String> idCounts = getMultiset(scheduledActivities);
+        Multiset<String> idCounts = getTaskIdsFromTaskReferences(scheduledActivities);
         assertEquals(1, idCounts.count("task:AAA"));
         assertEquals(2, idCounts.count("task:BBB"));
         
         scheduledActivities = usersApi.getScheduledActivities("+00:00", 4, 0).execute().body();
-        idCounts = getMultiset(scheduledActivities);
+        idCounts = getTaskIdsFromTaskReferences(scheduledActivities);
         assertEquals(1, idCounts.count("task:AAA"));
         assertEquals(0, idCounts.count("task:BBB"));
         
         scheduledActivities = usersApi.getScheduledActivities("+00:00", 4, 5).execute().body();
-        idCounts = getMultiset(scheduledActivities);
+        idCounts = getTaskIdsFromTaskReferences(scheduledActivities);
         assertEquals(1, idCounts.count("task:AAA"));
         assertEquals(5, idCounts.count("task:BBB"));
     }
     
-    private Multiset<String> getMultiset(ScheduledActivityList scheduledActivities) {
+    private Multiset<String> getTaskIdsFromTaskReferences(ScheduledActivityList scheduledActivities) {
         return HashMultiset.create(scheduledActivities.getItems().stream()
+                .filter(activity -> activity.getActivity().getActivityType() == ActivityType.TASK)
                 .map((act) -> act.getActivity().getTask().getIdentifier())
                 .collect(Collectors.toList()));
     }


### PR DESCRIPTION
While testing the scheduler resolving schema revs changes, I noticed that ScheduledActivityTest assumes that the api study has no other schedule plans (and enforces this by deleting all the schedule plans in the study). I fixed the test to only delete the schedule plans it creates and to still function even when there are other schedule plans. This allows the integ test to function without interfering with other tests.

Testing done:
* Ran it locally against my scheduler changes. Verified that it neither leave behind extra schedule plans, nor did it delete existing schedule plans.
* Ran it against staging to verify that it works against the existing code.

Aforementioned scheduler changes are at https://github.com/Sage-Bionetworks/BridgePF/pull/1376 This integ test change helps test the BridgePF change, but strictly speaking, they can be checked in indepedently.