### PR TITLE
Switch to use of new activity history API.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.12.38</version>
+            <version>0.12.39</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduledActivityTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduledActivityTest.java
@@ -172,7 +172,7 @@ public class ScheduledActivityTest {
 
         // You can see this activity in history...
         ForwardCursorScheduledActivityList list = usersApi.getActivityHistory(activity.getGuid(),
-                startDateTime, endDateTime, null, 5L).execute().body();
+                startDateTime, endDateTime, null, "5").execute().body();
 
         ScheduledActivity retrievedFromHistory = list.getItems().get(0);
         Tests.setVariableValueInObject(retrievedFromHistory, "schedulePlanGuid", schActivity.getSchedulePlanGuid());
@@ -221,7 +221,7 @@ public class ScheduledActivityTest {
         
         // But the activities continue to be in the history APIs
         list = usersApi.getActivityHistory(activity.getGuid(),
-                startDateTime, endDateTime, null, 5L).execute().body();
+                startDateTime, endDateTime, null, "5").execute().body();
         assertFalse(list.getItems().isEmpty());
         assertNotNull(list.getItems().get(0).getFinishedOn());
         


### PR DESCRIPTION
This will need to be adjusted to a new version number once other change is merged, but it's the first step to removing the older activity history API.