### PR TITLE
Update bridge java sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.12.64</version>
+            <version>0.12.65</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Pick up new version of bridge java sdk that includes
the feature to point at a different host (HOST ENV).