### PR TITLE
excludeStudyIdInExport flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.13.9</version>
+            <version>0.13.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyTest.java
@@ -209,8 +209,8 @@ public class StudyTest {
         assertNull("study version should be null", study.getVersion());
 
         // Set these flags to false to verify that studies are always created with these flags set to true.
-        study.setExcludeStudyIdInExport(false);
         study.setStrictUploadValidationEnabled(false);
+        study.setStudyIdExcludedInExport(false);
 
         VersionHolder holder = studiesApi.createStudy(study).execute().body();
         assertNotNull(holder.getVersion());
@@ -245,8 +245,8 @@ public class StudyTest {
         assertEquals("iOS push ARN should be equal", study.getPushNotificationARNs().get("iPhone OS"),
                 newStudy.getPushNotificationARNs().get("iPhone OS"));        
 
-        assertTrue("excludeStudyIdInExport should be true", newStudy.getExcludeStudyIdInExport());
         assertTrue("strictUploadValidationEnabled should be true", newStudy.getStrictUploadValidationEnabled());
+        assertTrue("studyIdExcludedInExport should be true", newStudy.getStudyIdExcludedInExport());
         assertTrue("healthCodeExportEnabled should be true", newStudy.getHealthCodeExportEnabled());
         assertTrue("emailVerificationEnabled should be true", newStudy.getEmailVerificationEnabled());
         assertTrue("emailSignInEnabled should be true", newStudy.getEmailSignInEnabled());
@@ -278,15 +278,15 @@ public class StudyTest {
         
         // Set stuff that only an admin can set.
         newerStudy.setEmailSignInEnabled(false);
-        newerStudy.setExcludeStudyIdInExport(false);
         newerStudy.setStrictUploadValidationEnabled(false);
+        newerStudy.setStudyIdExcludedInExport(false);
         studiesApi.updateStudy(newerStudy.getIdentifier(), newerStudy).execute().body();
         Study newestStudy = studiesApi.getStudy(newStudy.getIdentifier()).execute().body();
 
         assertFalse("emailSignInEnabled should be false after update", newestStudy.getEmailSignInEnabled());
-        assertFalse("excludeStudyIdInExport should be false after update", newestStudy.getExcludeStudyIdInExport());
         assertFalse("strictValidationEnabled should be false after update", newestStudy
                 .getStrictUploadValidationEnabled());
+        assertFalse("studyIdExcludedInExport should be false after update", newestStudy.getStudyIdExcludedInExport());
 
         // logically delete a study by admin
         studiesApi.deleteStudy(studyId, false).execute();
@@ -354,17 +354,17 @@ public class StudyTest {
             StudiesApi studiesApi = developer.getClient(StudiesApi.class);
 
             Study study = studiesApi.getUsersStudy().execute().body();
-            study.setExcludeStudyIdInExport(false);
             study.setHealthCodeExportEnabled(true);
             study.setEmailVerificationEnabled(false);
             study.setStrictUploadValidationEnabled(false);
+            study.setStudyIdExcludedInExport(false);
             studiesApi.updateUsersStudy(study).execute();
 
             study = studiesApi.getUsersStudy().execute().body();
-            assertTrue("excludeStudyIdInExport should be true", study.getExcludeStudyIdInExport());
             assertFalse("healthCodeExportEnabled should be false", study.getHealthCodeExportEnabled());
             assertTrue("emailVersificationEnabled should be true", study.getEmailVerificationEnabled());
             assertTrue("strictValidationEnabled should be true", study.getStrictUploadValidationEnabled());
+            assertTrue("studyIdExcludedInExport should be true", study.getStudyIdExcludedInExport());
         } finally {
             developer.signOutAndDeleteUser();
         }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
@@ -187,9 +187,11 @@ public class Tests {
     public static Study getStudy(String identifier, Long version) {
         Study study = new Study();
         study.setIdentifier(identifier);
+        study.setExcludeStudyIdInExport(true);
         study.setMinAgeOfConsent(18);
         study.setName("Test Study [SDK]");
         study.setSponsorName("The Test Study Folks [SDK]");
+        study.setStrictUploadValidationEnabled(true);
         study.setSupportEmail("test@test.com");
         study.setConsentNotificationEmail("test2@test.com");
         study.setTechnicalEmail("test3@test.com");

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
@@ -187,11 +187,11 @@ public class Tests {
     public static Study getStudy(String identifier, Long version) {
         Study study = new Study();
         study.setIdentifier(identifier);
-        study.setExcludeStudyIdInExport(true);
         study.setMinAgeOfConsent(18);
         study.setName("Test Study [SDK]");
         study.setSponsorName("The Test Study Folks [SDK]");
         study.setStrictUploadValidationEnabled(true);
+        study.setStudyIdExcludedInExport(true);
         study.setSupportEmail("test@test.com");
         study.setConsentNotificationEmail("test2@test.com");
         study.setTechnicalEmail("test3@test.com");


### PR DESCRIPTION
See https://github.com/Sage-Bionetworks/BridgePF/pull/1554 and https://github.com/Sage-Bionetworks/BridgeJavaSDK/pull/433

Note that tests will fail unless the api study is set with excludeStudyIdInExport=true. (This setting is needed to test BridgeEX changes.)