### PR TITLE
add sleep() to ParticipantsTest.getActivityHistoryV4()

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
@@ -461,8 +461,11 @@ public class ParticipantsTest {
             ParticipantsApi api = researcher.getClient(ParticipantsApi.class);
             
             ForwardCursorScheduledActivityList list = api
-                    .getParticipantTaskHistory(userId, taskReferentGuid, startsOn, endsOn, null, 100).execute().body();            
-            
+                    .getParticipantTaskHistory(userId, taskReferentGuid, startsOn, endsOn, null, 100).execute().body();
+
+            // getTaskHistory() uses a secondary global index. Sleep for 2 seconds to help make sure the index is consistent.
+            Thread.sleep(2000);
+
             // There should be activities...
             assertFalse(list.getItems().isEmpty());
             


### PR DESCRIPTION
getTaskHistory() uses a global secondary index. Sometimes it fails due to inconsistent index. Add a sleep to make this test fail less.