### PR TITLE
Remove retry

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthenticationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthenticationTest.java
@@ -156,7 +156,7 @@ public class AuthenticationTest {
                 
                 AuthenticationApi authClient = otherStudyManager.getClient(AuthenticationApi.class);
                 
-                authClient.signIn(otherStudySignIn).execute();
+                authClient.signInV4(otherStudySignIn).execute();
                 fail("Should not have allowed sign in");
             } catch (EntityNotFoundException e) {
                 assertEquals(404, e.getStatusCode());

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/IntentToParticipateTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/IntentToParticipateTest.java
@@ -99,7 +99,7 @@ public class IntentToParticipateTest {
         participant.setPhoneVerified(true);
         participantsApi.updateParticipant(participant.getId(), participant).execute();
         
-        session = authApi.signIn(signIn).execute().body();
+        session = authApi.signInV4(signIn).execute().body();
         assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, session.getSharingScope());
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignInTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignInTest.java
@@ -126,7 +126,7 @@ public class SignInTest {
 
         ClientManager newUserClientManager = new ClientManager.Builder().withSignIn(signIn).build();
         AuthenticationApi newUserAuthApi = newUserClientManager.getClient(AuthenticationApi.class);
-        newUserAuthApi.signIn(signIn).execute();
+        newUserAuthApi.signInV4(signIn).execute();
     }
 
     @Test(expected = EntityNotFoundException.class)
@@ -136,7 +136,7 @@ public class SignInTest {
 
         ClientManager newUserClientManager = new ClientManager.Builder().withSignIn(signIn).build();
         AuthenticationApi newUserAuthApi = newUserClientManager.getClient(AuthenticationApi.class);
-        newUserAuthApi.signIn(signIn).execute();
+        newUserAuthApi.signInV4(signIn).execute();
     }
 
     @Test(expected = EntityNotFoundException.class)
@@ -151,6 +151,6 @@ public class SignInTest {
         // Sign in should now fail with a 404 not found.
         ClientManager newUserClientManager = new ClientManager.Builder().withSignIn(user.getSignIn()).build();
         AuthenticationApi newUserAuthApi = newUserClientManager.getClient(AuthenticationApi.class);
-        newUserAuthApi.signIn(user.getSignIn()).execute();
+        newUserAuthApi.signInV4(user.getSignIn()).execute();
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignUpTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignUpTest.java
@@ -47,7 +47,7 @@ public class SignUpTest {
             authApi.signOut().execute();
             
             SignIn signIn = testUser.getSignIn();
-            UserSessionInfo session = authApi.signIn(signIn).execute().body();
+            UserSessionInfo session = authApi.signInV4(signIn).execute().body();
             
             assertTrue(session.getAuthenticated());
 

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SubpopulationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SubpopulationTest.java
@@ -149,7 +149,7 @@ public class SubpopulationTest {
             // required subpopulations
             try {
                 ClientManager manager = clientManager(user.getSignIn(), getClientInfoWithVersion("Android", 2));
-                manager.getClient(AuthenticationApi.class).signIn(user.getSignIn()).execute();
+                manager.getClient(AuthenticationApi.class).signInV4(user.getSignIn()).execute();
                 fail("Should have thrown exception");
             } catch(ConsentRequiredException e) {
                 Map<String,ConsentStatus> statuses = e.getSession().getConsentStatuses();
@@ -162,7 +162,7 @@ public class SubpopulationTest {
                 
                 ClientManager manager = null;
                 manager = clientManager(user.getSignIn(), getClientInfoWithVersion("Android", 12));    
-                manager.getClient(AuthenticationApi.class).signIn(user.getSignIn()).execute();
+                manager.getClient(AuthenticationApi.class).signInV4(user.getSignIn()).execute();
                 fail("Should have thrown exception");
             } catch(ConsentRequiredException e) {
                 Map<String,ConsentStatus> statuses = e.getSession().getConsentStatuses();
@@ -173,7 +173,7 @@ public class SubpopulationTest {
             try {
                 user.signOut();
                 ClientManager manager = clientManager(user.getSignIn(), getClientInfoWithVersion("iPhone OS", 12));
-                manager.getClient(AuthenticationApi.class).signIn(user.getSignIn()).execute();
+                manager.getClient(AuthenticationApi.class).signInV4(user.getSignIn()).execute();
                 fail("Should have thrown exception");
             } catch(ConsentRequiredException e) {
                 Map<String,ConsentStatus> statuses = e.getSession().getConsentStatuses();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/TestUserHelper.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/TestUserHelper.java
@@ -76,7 +76,7 @@ public class TestUserHelper {
         public UserSessionInfo signInAgain() {
             AuthenticationApi authApi = manager.getClient(AuthenticationApi.class);
             try {
-                UserSessionInfo session = authApi.signIn(getSignIn()).execute().body();
+                UserSessionInfo session = authApi.signInV4(getSignIn()).execute().body();
                 userId = session.getId();
                 return manager.getSessionOfClients();
             } catch(IOException ioe) {

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UTF8Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UTF8Test.java
@@ -61,7 +61,7 @@ public class UTF8Test {
             // Force a refresh of the Redis session cache.
             AuthenticationApi authApi = testUser.getClient(AuthenticationApi.class);
             authApi.signOut().execute();
-            UserSessionInfo session = authApi.signIn(testUser.getSignIn()).execute().body();
+            UserSessionInfo session = authApi.signInV4(testUser.getSignIn()).execute().body();
 
             assertEquals("☃", session.getFirstName());
             assertEquals("지구상의　３대　극지라　불리는", session.getLastName());

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserManagementTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserManagementTest.java
@@ -59,7 +59,7 @@ public class UserManagementTest {
         SignIn signIn = new SignIn().study(admin.getStudyId()).email(email).password(password);
         ClientManager newUserClientManager = new ClientManager.Builder().withSignIn(signIn).build();
         AuthenticationApi newUserAuthApi = newUserClientManager.getClient(AuthenticationApi.class);
-        newUserAuthApi.signIn(signIn).execute();
+        newUserAuthApi.signInV4(signIn).execute();
 
         // Creating the user again throws an EntityAlreadyExists.
         try {


### PR DESCRIPTION
As we now send a deprecation header with the v3 sign in API, it's pretty noisy in the logging. Moving to v4 sign in for our tests.