### PR TITLE
I put the sleep in the wrong place

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
@@ -526,12 +526,12 @@ public class ParticipantsTest {
             
             usersApi.getScheduledActivities("+00:00", 4, null).execute().body();
             ParticipantsApi api = researcher.getClient(ParticipantsApi.class);
-            
-            ForwardCursorScheduledActivityList list = api
-                    .getParticipantTaskHistory(userId, taskReferentGuid, startsOn, endsOn, null, 100).execute().body();
 
             // getTaskHistory() uses a secondary global index. Sleep for 2 seconds to help make sure the index is consistent.
             Thread.sleep(2000);
+
+            ForwardCursorScheduledActivityList list = api
+                    .getParticipantTaskHistory(userId, taskReferentGuid, startsOn, endsOn, null, 100).execute().body();
 
             // There should be activities...
             assertFalse(list.getItems().isEmpty());


### PR DESCRIPTION
ParticipantsTest.getActivityHistoryV4() uses a global secondary index. I added a sleep to try to make the test more robust. However, I originally put the sleep in a location that does nothing. (See https://github.com/Sage-Bionetworks/BridgeIntegrationTests/pull/199)

This change moves the sleep to a place that actually makes sense.