### PR TITLE
mpower 2.0 APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.15.9</version>
+            <version>0.15.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AppConfigTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AppConfigTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.sagebionetworks.bridge.rest.ApiClientProvider;
 import org.sagebionetworks.bridge.rest.RestUtils;
 import org.sagebionetworks.bridge.rest.api.AppConfigsApi;
+import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.PublicApi;
 import org.sagebionetworks.bridge.rest.api.StudiesApi;
 import org.sagebionetworks.bridge.rest.exceptions.EntityNotFoundException;
@@ -37,7 +38,7 @@ public class AppConfigTest {
     private TestUser developer;
     private TestUser admin;
 
-    private AppConfigsApi adminApi;
+    private ForAdminsApi adminApi;
     private AppConfigsApi devApi;
     
     @Before
@@ -45,7 +46,7 @@ public class AppConfigTest {
         developer = TestUserHelper.createAndSignInUser(ExternalIdsTest.class, false, Role.DEVELOPER);
         admin = TestUserHelper.getSignedInAdmin();
         
-        adminApi = admin.getClient(AppConfigsApi.class);
+        adminApi = admin.getClient(ForAdminsApi.class);
         devApi = developer.getClient(AppConfigsApi.class);
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/IntentToParticipateTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/IntentToParticipateTest.java
@@ -11,9 +11,9 @@ import org.sagebionetworks.bridge.rest.ClientManager;
 import org.sagebionetworks.bridge.rest.Config;
 import org.sagebionetworks.bridge.rest.RestUtils;
 import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
+import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.IntentToParticipateApi;
 import org.sagebionetworks.bridge.rest.api.ParticipantsApi;
-import org.sagebionetworks.bridge.rest.api.UsersApi;
 import org.sagebionetworks.bridge.rest.model.AccountStatus;
 import org.sagebionetworks.bridge.rest.model.AccountSummaryList;
 import org.sagebionetworks.bridge.rest.model.ConsentSignature;
@@ -47,8 +47,8 @@ public class IntentToParticipateTest {
     @After
     public void deleteUser() throws Exception {
         if (session != null) {
-            UsersApi userApi = admin.getClient(UsersApi.class);
-            userApi.deleteUser(session.getId()).execute();
+            ForAdminsApi adminApi = admin.getClient(ForAdminsApi.class);
+            adminApi.deleteUser(session.getId()).execute();
         }
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthTest.java
@@ -7,9 +7,9 @@ import static org.junit.Assert.fail;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
 import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
-import org.sagebionetworks.bridge.rest.api.StudiesApi;
 import org.sagebionetworks.bridge.rest.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.rest.model.ForwardCursorStringList;
 import org.sagebionetworks.bridge.rest.model.OAuthAuthorizationToken;
@@ -66,14 +66,14 @@ public class OAuthTest {
         } catch(EntityNotFoundException e) {
             assertEquals("OAuthProvider not found.", e.getMessage());
         }
-        StudiesApi studiesApi = admin.getClient(StudiesApi.class);
-        Study study = studiesApi.getStudy(worker.getStudyId()).execute().body();
+        ForAdminsApi adminApi = admin.getClient(ForAdminsApi.class);
+        Study study = adminApi.getStudy(worker.getStudyId()).execute().body();
         try {
             OAuthProvider provider = new OAuthProvider().clientId("foo").endpoint("https://webservices.sagebridge.org/")
                     .callbackUrl("https://webservices.sagebridge.org/").secret("secret");
             
             study.getOAuthProviders().put("bridge", provider);
-            VersionHolder version = studiesApi.updateStudy(study.getIdentifier(), study).execute().body();
+            VersionHolder version = adminApi.updateStudy(study.getIdentifier(), study).execute().body();
             study.setVersion(version.getVersion()); 
             
             ForwardCursorStringList list = workersApi.getHealthCodesGrantingOAuthAccess(worker.getStudyId(), "bridge", null, null).execute().body();
@@ -86,7 +86,7 @@ public class OAuthTest {
             }
         } finally {
             study.getOAuthProviders().remove("bridge");
-            studiesApi.updateStudy(study.getIdentifier(), study).execute();
+            adminApi.updateStudy(study.getIdentifier(), study).execute();
         }
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
@@ -25,7 +25,6 @@ import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
 import org.sagebionetworks.bridge.rest.api.ParticipantsApi;
 import org.sagebionetworks.bridge.rest.api.SchedulesApi;
-import org.sagebionetworks.bridge.rest.api.StudiesApi;
 import org.sagebionetworks.bridge.rest.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.rest.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.rest.model.AccountStatus;
@@ -79,12 +78,12 @@ public class ParticipantsTest {
                 .withExternalId(Tests.randomIdentifier(ParticipantsTest.class)).createAndSignInUser();
         Tests.deletePhoneUser(researcher);
         
-        StudiesApi studiesApi = admin.getClient(StudiesApi.class);
-        Study study = studiesApi.getUsersStudy().execute().body();
+        ForAdminsApi adminApi = admin.getClient(ForAdminsApi.class);
+        Study study = adminApi.getUsersStudy().execute().body();
         if (!study.getPhoneSignInEnabled() || !study.getEmailSignInEnabled()) {
             study.setPhoneSignInEnabled(true);
             study.setEmailSignInEnabled(true);
-            studiesApi.updateStudy(study.getIdentifier(), study).execute();
+            adminApi.updateStudy(study.getIdentifier(), study).execute();
         }
     }
     
@@ -157,11 +156,11 @@ public class ParticipantsTest {
     @Test
     public void retrieveParticipant() throws Exception {
         ParticipantsApi participantsApi = researcher.getClient(ParticipantsApi.class);
-        StudiesApi studiesApi = admin.getClient(StudiesApi.class);
-        Study study = studiesApi.getStudy(admin.getStudyId()).execute().body();
+        ForAdminsApi adminApi = admin.getClient(ForAdminsApi.class);
+        Study study = adminApi.getStudy(admin.getStudyId()).execute().body();
         try {
             study.setHealthCodeExportEnabled(true);
-            VersionHolder version = studiesApi.updateStudy(study.getIdentifier(), study).execute().body();
+            VersionHolder version = adminApi.updateStudy(study.getIdentifier(), study).execute().body();
             study.version(version.getVersion());
             
             StudyParticipant participant = participantsApi.getParticipantById(researcher.getSession().getId(), true).execute().body();
@@ -182,7 +181,7 @@ public class ParticipantsTest {
             assertNull(participant3.getConsentHistories().get("api"));
         } finally {
             study.setHealthCodeExportEnabled(false);
-            VersionHolder version = studiesApi.updateStudy(study.getIdentifier(), study).execute().body();
+            VersionHolder version = adminApi.updateStudy(study.getIdentifier(), study).execute().body();
             study.version(version.getVersion());
         }
     }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ReauthenticationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ReauthenticationTest.java
@@ -10,8 +10,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
+import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
-import org.sagebionetworks.bridge.rest.api.StudiesApi;
 import org.sagebionetworks.bridge.rest.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.rest.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.rest.model.SignIn;
@@ -52,21 +52,21 @@ public class ReauthenticationTest {
     @BeforeClass
     public static void turnOnReauthentication() throws Exception {
         TestUser admin = TestUserHelper.getSignedInAdmin();
-        StudiesApi studiesApi = admin.getClient(StudiesApi.class);
+        ForAdminsApi adminApi = admin.getClient(ForAdminsApi.class);
         
-        Study study = studiesApi.getStudy("api").execute().body();
+        Study study = adminApi.getStudy("api").execute().body();
         study.setReauthenticationEnabled(true);
-        studiesApi.updateStudy("api", study).execute();
+        adminApi.updateStudy("api", study).execute();
     }
     
     @AfterClass
     public static void turnOffReauthentication() throws Exception {
         TestUser admin = TestUserHelper.getSignedInAdmin();
-        StudiesApi studiesApi = admin.getClient(StudiesApi.class);
+        ForAdminsApi adminApi = admin.getClient(ForAdminsApi.class);
         
-        Study study = studiesApi.getStudy("api").execute().body();
+        Study study = adminApi.getStudy("api").execute().body();
         study.setReauthenticationEnabled(false);
-        studiesApi.updateStudy("api", study).execute();
+        adminApi.updateStudy("api", study).execute();
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SharedModuleMetadataTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SharedModuleMetadataTest.java
@@ -22,7 +22,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.SharedModulesApi;
 import org.sagebionetworks.bridge.rest.api.SurveysApi;
 import org.sagebionetworks.bridge.rest.api.UploadSchemasApi;
@@ -57,7 +57,7 @@ public class SharedModuleMetadataTest {
     private static SharedModulesApi nonAuthSharedModulesApi;
     private static UploadSchemasApi devUploadSchemasApi;
     private static SurveysApi devSurveysApi;
-    private static UploadSchemasApi adminUploadSchemasApi;
+    private static ForAdminsApi adminUploadSchemasApi;
     private static SurveysApi adminSurveysApi;
     private static String studyId;
 
@@ -77,7 +77,7 @@ public class SharedModuleMetadataTest {
         devUploadSchemasApi = sharedDeveloper.getClient(UploadSchemasApi.class);
         devSurveysApi = sharedDeveloper.getClient(SurveysApi.class);
         studyId = sharedDeveloper.getStudyId();
-        adminUploadSchemasApi = admin.getClient(UploadSchemasApi.class);
+        adminUploadSchemasApi = admin.getClient(ForAdminsApi.class);
         adminSurveysApi = admin.getClient(SurveysApi.class);
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SharedModuleTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SharedModuleTest.java
@@ -12,7 +12,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.SharedModulesApi;
 import org.sagebionetworks.bridge.rest.api.SurveysApi;
 import org.sagebionetworks.bridge.rest.api.UploadSchemasApi;
@@ -63,8 +63,7 @@ public class SharedModuleTest {
     public void deleteTestObjects() throws Exception {
         // Delete schemas created by test. We do it in a single After method instead of multiple, in case there are any
         // referential integrity concerns.
-        UploadSchemasApi adminSchemaApi = admin.getClient(UploadSchemasApi.class);
-        SurveysApi adminSurveyApi = admin.getClient(SurveysApi.class);
+        ForAdminsApi adminApi = admin.getClient(ForAdminsApi.class);
 
         if (module != null) {
             try {
@@ -77,8 +76,8 @@ public class SharedModuleTest {
 
         if (localSchema != null) {
             try {
-                adminSchemaApi.deleteAllRevisionsOfUploadSchema(apiDeveloper.getStudyId(),
-                        localSchema.getSchemaId()).execute();
+                adminApi.deleteAllRevisionsOfUploadSchema(apiDeveloper.getStudyId(), localSchema.getSchemaId())
+                        .execute();
             } catch (BridgeSDKException ex) {
                 LOG.error("Error deleting schema " + localSchema.getSchemaId() + " in study " +
                         apiDeveloper.getStudyId() + ": "  + ex.getMessage(), ex);
@@ -87,8 +86,8 @@ public class SharedModuleTest {
 
         if (sharedSchema != null) {
             try {
-                adminSchemaApi.deleteAllRevisionsOfUploadSchema(sharedDeveloper.getStudyId(),
-                        sharedSchema.getSchemaId()).execute();
+                adminApi.deleteAllRevisionsOfUploadSchema(sharedDeveloper.getStudyId(), sharedSchema.getSchemaId())
+                        .execute();
             } catch (BridgeSDKException ex) {
                 LOG.error("Error deleting schema " + sharedSchema.getSchemaId() + " in study " +
                         sharedDeveloper.getStudyId() + ": "  + ex.getMessage(), ex);
@@ -97,7 +96,7 @@ public class SharedModuleTest {
 
         if (localSurvey != null) {
             try {
-                adminSurveyApi.deleteSurvey(localSurvey.getGuid(), localSurvey.getCreatedOn(), true).execute();
+                adminApi.deleteSurvey(localSurvey.getGuid(), localSurvey.getCreatedOn(), true).execute();
             } catch (BridgeSDKException ex) {
                 LOG.error("Error deleting local survey " + sharedSurvey.getGuid() + ": "  + ex.getMessage(), ex);
             }
@@ -105,7 +104,7 @@ public class SharedModuleTest {
 
         if (sharedSurvey != null) {
             try {
-                adminSurveyApi.deleteSurvey(sharedSurvey.getGuid(), sharedSurvey.getCreatedOn(), true).execute();
+                adminApi.deleteSurvey(sharedSurvey.getGuid(), sharedSurvey.getCreatedOn(), true).execute();
             } catch (BridgeSDKException ex) {
                 LOG.error("Error deleting shared survey " + sharedSurvey.getGuid() + ": "  + ex.getMessage(), ex);
             }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
@@ -35,11 +35,11 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
+import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
 import org.sagebionetworks.bridge.rest.api.SchedulesApi;
 import org.sagebionetworks.bridge.rest.api.SharedModulesApi;
-import org.sagebionetworks.bridge.rest.api.StudiesApi;
 import org.sagebionetworks.bridge.rest.api.SurveysApi;
 import org.sagebionetworks.bridge.rest.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.rest.exceptions.ConstraintViolationException;
@@ -513,14 +513,14 @@ public class SurveyTest {
         surveysApi.publishSurvey(survey2bKeys.getGuid(), survey2bKeys.getCreatedOn(), false).execute();
 
         // Sleep to clear eventual consistency problems.
-        SurveysApi workerSurveyClient = worker.getClient(SurveysApi.class);
+        ForWorkersApi workerApi = worker.getClient(ForWorkersApi.class);
         Thread.sleep(2000);
 
         // The surveys we created were just dummies. Just check that the surveys are not null and that the keys match.
-        Survey survey1a = workerSurveyClient.getSurvey(survey1aKeys.getGuid(), survey1aKeys.getCreatedOn()).execute().body();
-        Survey survey1b = workerSurveyClient.getSurvey(survey1bKeys.getGuid(), survey1bKeys.getCreatedOn()).execute().body();
-        Survey survey2a = workerSurveyClient.getSurvey(survey2aKeys.getGuid(), survey2aKeys.getCreatedOn()).execute().body();
-        Survey survey2b = workerSurveyClient.getSurvey(survey2bKeys.getGuid(), survey2bKeys.getCreatedOn()).execute().body();
+        Survey survey1a = workerApi.getSurvey(survey1aKeys.getGuid(), survey1aKeys.getCreatedOn()).execute().body();
+        Survey survey1b = workerApi.getSurvey(survey1bKeys.getGuid(), survey1bKeys.getCreatedOn()).execute().body();
+        Survey survey2a = workerApi.getSurvey(survey2aKeys.getGuid(), survey2aKeys.getCreatedOn()).execute().body();
+        Survey survey2b = workerApi.getSurvey(survey2bKeys.getGuid(), survey2bKeys.getCreatedOn()).execute().body();
 
         assertKeysEqual(survey1aKeys, survey1a);
         assertKeysEqual(survey1bKeys, survey1b);
@@ -528,11 +528,11 @@ public class SurveyTest {
         assertKeysEqual(survey2bKeys, survey2b);
 
         // Get using the guid+createdOn API for completeness.
-        Survey survey1aAgain = workerSurveyClient.getSurvey(survey1aKeys.getGuid(), survey1aKeys.getCreatedOn()).execute().body();
+        Survey survey1aAgain = workerApi.getSurvey(survey1aKeys.getGuid(), survey1aKeys.getCreatedOn()).execute().body();
         assertKeysEqual(survey1aKeys, survey1aAgain);
 
         // We only expect the most recently published versions, namely 1b and 2b.
-        SurveyList surveyResourceList = workerSurveyClient.getAllPublishedSurveysInStudy(Tests.STUDY_ID).execute().body();
+        SurveyList surveyResourceList = workerApi.getAllPublishedSurveys(Tests.STUDY_ID).execute().body();
         containsAll(surveyResourceList.getItems(), new MutableHolder(survey1b), new MutableHolder(survey2b));
     }
 
@@ -635,8 +635,8 @@ public class SurveyTest {
     
     @Test
     public void canCreateAndSaveVariousKindsOfBeforeRules() throws Exception {
-        StudiesApi studiesApi = admin.getClient(StudiesApi.class);
-        Study study = studiesApi.getStudy(admin.getStudyId()).execute().body();
+        ForAdminsApi adminsApi = admin.getClient(ForAdminsApi.class);
+        Study study = adminsApi.getStudy(admin.getStudyId()).execute().body();
         String dataGroup = study.getDataGroups().get(0);
 
         Survey survey = TestSurvey.getSurvey(SurveyTest.class);
@@ -684,8 +684,8 @@ public class SurveyTest {
     
     @Test
     public void canCreateAndSaveVariousKindsOfAfterRules() throws Exception {
-        StudiesApi studiesApi = admin.getClient(StudiesApi.class);
-        Study study = studiesApi.getStudy(admin.getStudyId()).execute().body();
+        ForAdminsApi adminsApi = admin.getClient(ForAdminsApi.class);
+        Study study = adminsApi.getStudy(admin.getStudyId()).execute().body();
         String dataGroup = study.getDataGroups().get(0);
 
         Survey survey = TestSurvey.getSurvey(SurveyTest.class);
@@ -727,8 +727,8 @@ public class SurveyTest {
     
     @Test
     public void displayActionsInAfterRulesValidated() throws Exception {
-        StudiesApi studiesApi = admin.getClient(StudiesApi.class);
-        Study study = studiesApi.getStudy(admin.getStudyId()).execute().body();
+        ForAdminsApi adminsApi = admin.getClient(ForAdminsApi.class);
+        Study study = adminsApi.getStudy(admin.getStudyId()).execute().body();
         String dataGroup = study.getDataGroups().get(0);
 
         Survey survey = TestSurvey.getSurvey(SurveyTest.class);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UTF8Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UTF8Test.java
@@ -3,8 +3,8 @@ package org.sagebionetworks.bridge.sdk.integration;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
+import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
-import org.sagebionetworks.bridge.rest.api.StudiesApi;
 import org.sagebionetworks.bridge.rest.model.Study;
 import org.sagebionetworks.bridge.rest.model.StudyParticipant;
 import org.sagebionetworks.bridge.rest.model.UserSessionInfo;
@@ -18,7 +18,7 @@ public class UTF8Test {
     public void canSaveAndRetrieveDataStoredInDynamo() throws Exception {
         String studyId = Tests.randomIdentifier(UTF8Test.class);
         String studyName = "☃지구상의　３대　극지라　불리는";
-        StudiesApi studiesApi = TestUserHelper.getSignedInAdmin().getClient(StudiesApi.class);
+        ForAdminsApi adminApi = TestUserHelper.getSignedInAdmin().getClient(ForAdminsApi.class);
 
         // make minimal study
         Study study = new Study();
@@ -33,16 +33,16 @@ public class UTF8Test {
         study.setEmailVerificationEnabled(true);
 
         // create study
-        studiesApi.createStudy(study).execute();
+        adminApi.createStudy(study).execute();
 
         try {
             // get study back and verify fields
-            Study returnedStudy = studiesApi.getStudy(studyId).execute().body();
+            Study returnedStudy = adminApi.getStudy(studyId).execute().body();
             assertEquals(studyId, returnedStudy.getIdentifier());
             assertEquals(studyName, returnedStudy.getName());
         } finally {
             // clean-up: delete study
-            studiesApi.deleteStudy(studyId, true).execute();
+            adminApi.deleteStudy(studyId, true).execute();
         }
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
@@ -163,7 +163,7 @@ public class UploadSchemaTest {
 
         // Step 3b: Worker client can also get schemas, and can get schemas by study, schema, and rev.
         // This schema should be identical to updatedSchemaV2, except it also has the study ID.
-        UploadSchema workerSchemaV2 = workerUploadSchemasApi.getSchemaRevisionInStudy(Tests.STUDY_ID, schemaId, 2L).execute().body();
+        UploadSchema workerSchemaV2 = workerUploadSchemasApi.getSchemaRevision(Tests.STUDY_ID, schemaId, 2L).execute().body();
         assertEquals(Tests.STUDY_ID, workerSchemaV2.getStudyId());
         assertSchemaFilledIn(workerSchemaV2);
 

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/WorkerApiTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/WorkerApiTest.java
@@ -1,18 +1,30 @@
 package org.sagebionetworks.bridge.sdk.integration;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
+import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
+import org.sagebionetworks.bridge.rest.api.ForResearchersApi;
 import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
+import org.sagebionetworks.bridge.rest.api.SchedulesApi;
 import org.sagebionetworks.bridge.rest.model.AccountSummaryList;
+import org.sagebionetworks.bridge.rest.model.ActivityEventList;
+import org.sagebionetworks.bridge.rest.model.ForwardCursorScheduledActivityList;
+import org.sagebionetworks.bridge.rest.model.GuidVersionHolder;
 import org.sagebionetworks.bridge.rest.model.Role;
+import org.sagebionetworks.bridge.rest.model.SchedulePlan;
+import org.sagebionetworks.bridge.rest.model.SchedulePlanList;
 import org.sagebionetworks.bridge.rest.model.SignUp;
+import org.sagebionetworks.bridge.rest.model.SimpleScheduleStrategy;
+import org.sagebionetworks.bridge.rest.model.SmsTemplate;
 import org.sagebionetworks.bridge.rest.model.StudyParticipant;
 import org.sagebionetworks.bridge.sdk.integration.TestUserHelper.TestUser;
 
@@ -20,6 +32,7 @@ public class WorkerApiTest {
     
     TestUser worker;
     TestUser researcher;
+    TestUser developer;
     TestUser phoneUser;
     TestUser user;
     ForWorkersApi workersApi;
@@ -28,6 +41,7 @@ public class WorkerApiTest {
     public void before() throws Exception {
         worker = TestUserHelper.createAndSignInUser(WorkerApiTest.class, true, Role.WORKER);
         researcher = TestUserHelper.createAndSignInUser(WorkerApiTest.class, true, Role.RESEARCHER);
+        developer = TestUserHelper.createAndSignInUser(WorkerApiTest.class, true, Role.DEVELOPER);
         workersApi = worker.getClient(ForWorkersApi.class);
     }
 
@@ -50,6 +64,12 @@ public class WorkerApiTest {
         }
     }
     @After
+    public void deleteDeveloper() throws Exception {
+        if (developer != null) {
+            developer.signOutAndDeleteUser();
+        }
+    }
+    @After
     public void deleteUser() throws Exception {
         if (user != null) {
             user.signOutAndDeleteUser();
@@ -62,28 +82,28 @@ public class WorkerApiTest {
         user = new TestUserHelper.Builder(WorkerApiTest.class).withConsentUser(true)
                 .withExternalId(externalId).createAndSignInUser();
         
-        AccountSummaryList list = workersApi.getParticipantsInStudy("api", 0, 5, "", null, null, null).execute().body();
+        AccountSummaryList list = workersApi.getParticipants("api", 0, 5, "", null, null, null).execute().body();
         assertTrue(list.getTotal() > 0);
         
-        list = workersApi.getParticipantsInStudy("api", 0, 5, worker.getEmail(), null, null, null).execute().body();
+        list = workersApi.getParticipants("api", 0, 5, worker.getEmail(), null, null, null).execute().body();
         assertEquals(1, list.getItems().size());
         assertEquals(worker.getEmail(), list.getItems().get(0).getEmail());
         
         // Include consent history in this call.
-        StudyParticipant participant = workersApi.getParticipantInStudyById("api", user.getSession().getId(), true)
+        StudyParticipant participant = workersApi.getParticipantById("api", user.getSession().getId(), true)
                 .execute().body();
         assertEquals(user.getEmail(), participant.getEmail());
         assertNotNull(participant.getHealthCode());
         assertNotNull(participant.getConsentHistories().get("api").get(0));
         
         // get by health code, also verify we do not include consent histories.
-        StudyParticipant participant2 = workersApi.getParticipantInStudyByHealthCode("api", participant.getHealthCode(), false)
+        StudyParticipant participant2 = workersApi.getParticipantByHealthCode("api", participant.getHealthCode(), false)
                 .execute().body();
         assertEquals(participant.getId(), participant2.getId());
         assertNull(participant2.getConsentHistories().get("api"));
         
         // get by external Id, also verify we do not include consent histories.
-        StudyParticipant participant3 = workersApi.getParticipantInStudyByExternalId("api", externalId, false)
+        StudyParticipant participant3 = workersApi.getParticipantByExternalId("api", externalId, false)
                 .execute().body();
         assertEquals(participant.getId(), participant3.getId());
         assertNull(participant3.getConsentHistories().get("api"));
@@ -96,15 +116,119 @@ public class WorkerApiTest {
         SignUp signUp = new SignUp().phone(Tests.PHONE).password("P@ssword`1");
         phoneUser = TestUserHelper.createAndSignInUser(WorkerApiTest.class, true, signUp);
         
-        AccountSummaryList list = workersApi.getParticipantsInStudy("api", 0, 5, null, "248-6796", null, null).execute().body();
+        AccountSummaryList list = workersApi.getParticipants("api", 0, 5, null, "248-6796", null, null).execute().body();
         assertEquals(1, list.getItems().size());
         assertEquals(phoneUser.getPhone().getNumber(), list.getItems().get(0).getPhone().getNumber());
         
         String userId = list.getItems().get(0).getId();
-        StudyParticipant participant = workersApi.getParticipantInStudyById("api", userId, false).execute().body();
+        StudyParticipant participant = workersApi.getParticipantById("api", userId, false).execute().body();
         
         assertEquals(phoneUser.getPhone().getNumber(), participant.getPhone().getNumber());
         assertNotNull(participant.getHealthCode());
+    }
+    
+    @Test
+    public void retrieveStudiesSchedulePlans() throws Exception {
+        SchedulePlan plan = Tests.getABTestSchedulePlan();
+        SchedulesApi planApi = developer.getClient(SchedulesApi.class);
+        GuidVersionHolder guid = null;
+        try {
+            guid = planApi.createSchedulePlan(plan).execute().body();
+            
+            SchedulePlanList plans = workersApi.getSchedulePlans("api").execute().body();
+            
+            final String theGuid = guid.getGuid();
+            if (!plans.getItems().stream().anyMatch((onePlan) -> onePlan.getGuid().equals(theGuid))) {
+                fail("Should have found schedule plan.");
+            }
+        } finally {
+            if (guid != null) {
+                planApi.deleteSchedulePlan(guid.getGuid()).execute();    
+            }
+        }
+    }
+    
+    @Test
+    public void retrieveUsersActivityEvents() throws Exception {
+        ActivityEventList list = workersApi
+                .getActivityEventsForParticipant(worker.getStudyId(), worker.getSession().getId()).execute().body();
+        
+        assertFalse(list.getItems().isEmpty());
+    }
+    
+    @Test
+    public void retrieveUsersActivities() throws Exception {
+        SchedulePlan plan = Tests.getDailyRepeatingSchedulePlan();
+        SchedulesApi planApi = developer.getClient(SchedulesApi.class);
+        
+        user = new TestUserHelper.Builder(WorkerApiTest.class).withConsentUser(true).createAndSignInUser();
+        
+        GuidVersionHolder guid = null;
+        try {
+            guid = planApi.createSchedulePlan(plan).execute().body();
+            plan = planApi.getSchedulePlan(guid.getGuid()).execute().body();
+            
+            ForConsentedUsersApi userApi = user.getClient(ForConsentedUsersApi.class);
+            userApi.getScheduledActivities("-07:00", 4, 1).execute();
+            
+            String activityGuid = ((SimpleScheduleStrategy) plan.getStrategy())
+                    .getSchedule().getActivities().get(0).getGuid();
+            ForwardCursorScheduledActivityList list = workersApi.getParticipantActivityHistory(
+                    user.getStudyId(), user.getSession().getId(), activityGuid, DateTime.now().minusDays(2), 
+                    DateTime.now().plusDays(2), null, 50).execute().body();
+
+            assertFalse(list.getItems().isEmpty());
+        } finally {
+            if (guid != null) {
+                planApi.deleteSchedulePlan(guid.getGuid()).execute();    
+            }
+        }
+    }
+    
+    @Test
+    public void retrieveUsersActivitiesByType() throws Exception {
+        SchedulePlan plan = Tests.getDailyRepeatingSchedulePlan();
+        SchedulesApi planApi = developer.getClient(SchedulesApi.class);
+        
+        user = new TestUserHelper.Builder(WorkerApiTest.class).withConsentUser(true).createAndSignInUser();
+        
+        GuidVersionHolder guid = null;
+        try {
+            guid = planApi.createSchedulePlan(plan).execute().body();
+            plan = planApi.getSchedulePlan(guid.getGuid()).execute().body();
+            
+            ForConsentedUsersApi userApi = user.getClient(ForConsentedUsersApi.class);
+            userApi.getScheduledActivities("-07:00", 4, 1).execute();
+            
+            ForwardCursorScheduledActivityList list = workersApi.getParticipantTaskHistory(user.getStudyId(), 
+                    user.getSession().getId(), "task:CCC", DateTime.now().minusDays(2), DateTime.now().plusDays(2), 
+                    null, 50).execute().body();
+
+            assertFalse(list.getItems().isEmpty());
+        } finally {
+            if (guid != null) {
+                planApi.deleteSchedulePlan(guid.getGuid()).execute();    
+            }
+        }
+    }
+    
+    @Test
+    public void sendUserSmsMessage() throws Exception {
+        SignUp signUp = new SignUp();
+        signUp.setPhone(Tests.PHONE);    
+        signUp.setStudy(Tests.STUDY_ID);
+        signUp.setConsent(true);
+        
+        user = new TestUserHelper.Builder(WorkerApiTest.class).withSignUp(signUp).withConsentUser(true)
+                .createAndSignInUser();
+
+        // It doesn't fail...
+        SmsTemplate message = new SmsTemplate().message("Test message.");
+        workersApi.sendSmsMessageToParticipant(user.getStudyId(), user.getSession().getId(), message).execute();
+        
+        ForResearchersApi researcherApi = researcher.getClient(ForResearchersApi.class);
+        
+        researcherApi.sendSmsMessageToParticipant(user.getSession().getId(), message).execute();
     }
     
 }


### PR DESCRIPTION
Also moving calls that are specific to workers and admins to the ForWorkersApi and ForAdminsApi clients, because external end users would just have to wade through these calls in the API and the could cause confusion.