### PR TITLE
Fix for BRIDGE-2410

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ReauthenticationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ReauthenticationTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.sdk.integration;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -116,10 +117,11 @@ public class ReauthenticationTest {
 
         Thread.sleep(REAUTH_CACHE_IN_MILLIS);
         
-        // Using the same token again right away now returns a fresh session.
+        // Using the same token again right away now returns a fresh session, but the
+        // tokens need to be the same.
         UserSessionInfo sessionTwo = authApi.reauthenticate(request).execute().body();
-        assertNotEquals(sessionOne.getSessionToken(), sessionTwo.getSessionToken());
-        assertNotEquals(sessionOne.getReauthToken(), sessionTwo.getReauthToken());
+        assertEquals(sessionOne.getSessionToken(), sessionTwo.getSessionToken());
+        assertEquals(sessionOne.getReauthToken(), sessionTwo.getReauthToken());
 
         Thread.sleep(REAUTH_CACHE_IN_MILLIS);
         


### PR DESCRIPTION
These tokens should not be the same, and not different, after a second reauthentication call using the same token.