### PR TITLE
Improve reliability of AccountSummarySearchTest

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AccountSummarySearchTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AccountSummarySearchTest.java
@@ -164,7 +164,7 @@ public class AccountSummarySearchTest {
         listsMatch(Lists.newArrayList("sdk-int-2"), list.getRequestParams().getAllOfGroups());
         
         // Successful "noneOfGroups" search
-        search = new AccountSummarySearch().noneOfGroups(Lists.newArrayList("group1"));
+        search = new AccountSummarySearch().noneOfGroups(Lists.newArrayList("group1")).pageSize(100);
         list = supplier.apply(search);
         userIds = mapUserIds(list);
         assertTrue(userIds.contains(testUser.getUserId()));
@@ -182,7 +182,7 @@ public class AccountSummarySearchTest {
         listsMatch(FRENCH_USER_GROUPS, list.getRequestParams().getNoneOfGroups());
         
         // This pulls up everything we're looking for
-        search = new AccountSummarySearch().noneOfGroups(Lists.newArrayList("sdk-int-2"));
+        search = new AccountSummarySearch().noneOfGroups(Lists.newArrayList("sdk-int-2")).pageSize(100);
         list = supplier.apply(search);
         userIds = mapUserIds(list);
         assertTrue(userIds.contains(testUser.getUserId()));

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SubstudyFilteringTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SubstudyFilteringTest.java
@@ -121,6 +121,12 @@ public class SubstudyFilteringTest {
                 e.printStackTrace();
             }
         }
+
+        try {
+            developer.signOutAndDeleteUser();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
     
     @Test


### PR DESCRIPTION
AccountSummarySearchTest was failing because staging had more than 50 accounts (the default for page size), so sometimes a query wouldn't include the accounts we were expecting. Staging had more than 50 accounts because SubstudyFilteringTest wasn't cleaning up its test developer account.

This fix is two-fold:
1. For the two queries that can hit most of the study, explicitly add a page size using the max page size. This makes it less likely that our accounts won't be included due to pagination.
2. Clean up SubstudyFilteringTest developer account.

If needed, more in-depth fixes in the future could include:
1. Paging through all accounts to ensure we have the full list of all accounts.
2. Alternatively, use an emailFilter for all queries and specify a unique email prefix for all accounts in this test. This ensures that other test accounts don't impact this test.