### PR TITLE
Updating integration tests to 0.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.16.37</version>
+            <version>0.17.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AccountSummarySearchTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AccountSummarySearchTest.java
@@ -109,7 +109,7 @@ public class AccountSummarySearchTest {
     @Test
     public void testSearchingApiForWorker() throws Exception {
         ForWorkersApi workerApi = worker.getClient(ForWorkersApi.class);
-        testSuite(search -> workerApi.searchAccountSummaries("api", search).execute().body());
+        testSuite(search -> workerApi.searchAccountSummariesForStudy("api", search).execute().body());
     }
     
     @FunctionalInterface

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ActivityEventTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ActivityEventTest.java
@@ -124,7 +124,7 @@ public class ActivityEventTest {
         assertEquals(timestamp, event.getTimestamp());
 
         // Verify researcher's view of created event
-        activityEventList = researchersApi.getActivityEvents(participant.getId()).execute().body();
+        activityEventList = researchersApi.getActivityEventsForParticipant(participant.getId()).execute().body();
         assertEquals(updatedActivityEvents, activityEventList.getItems());
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AppConfigTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AppConfigTest.java
@@ -213,7 +213,7 @@ public class AppConfigTest {
         assertNotEquals(secondOneRetrieved.getModifiedOn().toString(), firstOneRetrieved.getModifiedOn().toString());
         
         // You can get it as the user
-        AppConfig userAppConfig = studiesApi.getAppConfig(developer.getStudyId()).execute().body();
+        AppConfig userAppConfig = studiesApi.getAppConfigForStudy(developer.getStudyId()).execute().body();
         assertNotNull(userAppConfig);
         
         // Create a second app config
@@ -238,7 +238,7 @@ public class AppConfigTest {
         
         try {
             // This should not match the clientInfo provided
-            publicApi.getAppConfig(developer.getStudyId()).execute().body();
+            publicApi.getAppConfigForStudy(developer.getStudyId()).execute().body();
             fail("Should have thrown an exception");
         } catch(EntityNotFoundException e) {
             // None have matched
@@ -248,7 +248,7 @@ public class AppConfigTest {
         appConfigsApi.updateAppConfig(appConfig.getGuid(), appConfig).execute();
         
         // Having changed the config to match the criteria, we should be able to retrieve it.
-        AppConfig config = publicApi.getAppConfig(developer.getStudyId()).execute().body();
+        AppConfig config = publicApi.getAppConfigForStudy(developer.getStudyId()).execute().body();
         assertEquals(appConfig.getGuid(), config.getGuid());
         
         // test logical deletion
@@ -332,7 +332,7 @@ public class AppConfigTest {
         
         // Verify that for the user, the config is included in the app config itself
         ForConsentedUsersApi userApi = user.getClient(ForConsentedUsersApi.class);
-        AppConfig usersAppConfig = userApi.getAppConfig(user.getStudyId()).execute().body();
+        AppConfig usersAppConfig = userApi.getAppConfigForStudy(user.getStudyId()).execute().body();
         
         SchedulePlan plan = RestUtils.toType(usersAppConfig.getConfigElements().get(elementId), SchedulePlan.class);        
         assertEquals("Cron-based schedule", plan.getLabel());
@@ -343,7 +343,7 @@ public class AppConfigTest {
         element.setVersion(version.getVersion());
         
         // The user's config has been correctly updated
-        usersAppConfig = userApi.getAppConfig(user.getStudyId()).execute().body();
+        usersAppConfig = userApi.getAppConfigForStudy(user.getStudyId()).execute().body();
         SchedulePlan secondPlan = RestUtils.toType(usersAppConfig.getConfigElements().get(elementId), SchedulePlan.class);
         assertEquals("Persistent schedule", secondPlan.getLabel());
 

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ReportTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ReportTest.java
@@ -161,11 +161,11 @@ public class ReportTest {
         String userId = user.getSession().getId();
         ParticipantReportsApi reportsApi = developer.getClient(ParticipantReportsApi.class);
 
-        reportsApi.addParticipantReportRecord(userId, reportId, makeReportData(DATE1, "foo", "A"))
+        reportsApi.addParticipantReportRecordV4(userId, reportId, makeReportData(DATE1, "foo", "A"))
                 .execute();
-        reportsApi.addParticipantReportRecord(userId, reportId, makeReportData(DATE2, "bar", "B"))
+        reportsApi.addParticipantReportRecordV4(userId, reportId, makeReportData(DATE2, "bar", "B"))
                 .execute();
-        reportsApi.addParticipantReportRecord(userId, reportId, makeReportData(DATE3, "baz", "C"))
+        reportsApi.addParticipantReportRecordV4(userId, reportId, makeReportData(DATE3, "baz", "C"))
                 .execute();
 
         ForConsentedUsersApi usersApi = user.getClient(ForConsentedUsersApi.class);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduledActivityTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduledActivityTest.java
@@ -269,7 +269,7 @@ public class ScheduledActivityTest {
         surveyKeys = surveysApi.publishSurvey(surveyKeys.getGuid(), surveyKeys.getCreatedOn(), false).execute().body();
         
         Schedule schedule = new Schedule();
-        schedule.setLabel("Once Daily Task");
+        schedule.setLabel("Four Times Daily Task");
         schedule.setExpires("P1D");
         schedule.setInterval("P1D");
         schedule.setScheduleType(ScheduleType.RECURRING);
@@ -291,7 +291,7 @@ public class ScheduledActivityTest {
         strategy.setType("SimpleScheduleStrategy");
         
         SchedulePlan plan = new SchedulePlan();
-        plan.setLabel("Daily survey schedule plan");
+        plan.setLabel("Four times daily survey schedule plan");
         plan.setStrategy(strategy);
         String planGuid = schedulePlansApi.createSchedulePlan(plan).execute().body().getGuid();
         schedulePlanGuidList.add(planGuid);
@@ -777,10 +777,10 @@ public class ScheduledActivityTest {
             tries++;
             // Take the first request values to examine in origin test
             if (filteredList.getNextPageOffsetKey() == null) {
-                filteredList.nextPageOffsetKey(nextPageOffsetKey);        
+                Tests.setVariableValueInObject(filteredList,  "nextPageOffsetKey", nextPageOffsetKey);
             }
             if (filteredList.getRequestParams() == null) {
-                filteredList.requestParams(results.getRequestParams());    
+                Tests.setVariableValueInObject(filteredList,  "requestParams", results.getRequestParams());
             }
             
         } while(nextPageOffsetKey != null && tries < 100);
@@ -789,8 +789,7 @@ public class ScheduledActivityTest {
         } else if (pagesExpected && tries == 1) {
             fail("Expected more than one page of results, but only one page was returned");
         }
-        
-        filteredList.items(activities);
+        Tests.setVariableValueInObject(filteredList, "items", activities);
         return filteredList;
     }
     
@@ -807,7 +806,7 @@ public class ScheduledActivityTest {
         }
         // Take the first request values to examine in origin test
         if (filteredList.getRequestParams() == null) {
-            filteredList.requestParams(results.getRequestParams());    
+            Tests.setVariableValueInObject(filteredList, "requestParams", results.getRequestParams());
         }
         filteredList.items(activities);
         return filteredList;

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyTest.java
@@ -470,7 +470,7 @@ public class StudyTest {
         // that our Java SDK is set up correctly.
         StudiesApi studiesApi = admin.getClient(StudiesApi.class);
         try {
-            studiesApi.verifyEmail(IntegTestUtils.STUDY_ID, "dummy-token", "consent_notification").execute();
+            studiesApi.verifyEmailForStudy(IntegTestUtils.STUDY_ID, "dummy-token", "consent_notification").execute();
             fail("expected exception");
         } catch (BadRequestException ex) {
             assertTrue(ex.getMessage().contains("Email verification token has expired (or already been used)."));

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SubstudyFilteringTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SubstudyFilteringTest.java
@@ -161,7 +161,7 @@ public class SubstudyFilteringTest {
         // This should apply to any call involving user in another substudy, try one (fully tested in 
         // the unit tests)
         try {
-            researcherApiForB.getActivityEvents(userA.getId()).execute();
+            researcherApiForB.getActivityEventsForParticipant(userA.getId()).execute();
             fail("Should have thrown exception");
         } catch(EntityNotFoundException e) {
         }


### PR DESCRIPTION
Mostly operation name changes, and one place where I verified we can still set fields that are read-only for test purposes (using a reflection utility method).