### PR TITLE
fix ScheduledActivityTest

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduledActivityTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduledActivityTest.java
@@ -66,9 +66,10 @@ public class ScheduledActivityTest {
     private static final String TASK_ID = "task:AAA";
     private static final DateTimeZone EST = DateTimeZone.forOffsetHours(-5);
     // Ensure (using withHourOfDay) that we get four days of tasks despite the time of the test.
-    private static final DateTime STARTS_ON = DateTime.now(EST).withHourOfDay(2);
-    private static final DateTime ENDS_ON = STARTS_ON.plusDays(3).withHourOfDay(22);
-    
+    private static final DateTime NOW = DateTime.now();
+    private static final DateTime STARTS_ON = NOW.withZone(EST).withTimeAtStartOfDay();
+    private static final DateTime ENDS_ON = STARTS_ON.plusDays(4).withTimeAtStartOfDay();
+
     public static class ClientData {
         final String name;
         final boolean enabled;


### PR DESCRIPTION
Strictly speaking, it's not the test that's broken. However, the test was written in a way that reveals an obscure bug. (See https://sagebionetworks.jira.com/browse/BRIDGE-2448). This changes the test to avoid that bug to unblock integration tests.

Testing done:
1. Mocked both my local server and the integ tests to 4am UTC to repro the bug.
2. Changed the integ tests and verify (with the mocked time) that the change avoids the bug.
3. Unmocked the time and verified that the tests succeeds when run normally.