### PR TITLE
Updating to 0.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.18.0</version>
+            <version>0.19.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AppConfigTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AppConfigTest.java
@@ -48,6 +48,7 @@ import org.sagebionetworks.bridge.user.TestUserHelper;
 import org.sagebionetworks.bridge.user.TestUserHelper.TestUser;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
@@ -166,7 +167,7 @@ public class AppConfigTest {
         participant.setExternalId("externalId");
         
         Criteria criteria = new Criteria();
-        criteria.getMaxAppVersions().put("Android", 10);
+        criteria.setMaxAppVersions(ImmutableMap.of("Android", 10));
         
         AppConfig appConfig = new AppConfig();
         appConfig.setLabel(Tests.randomIdentifier(AppConfigTest.class));

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SchedulePlanTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SchedulePlanTest.java
@@ -40,6 +40,7 @@ import org.sagebionetworks.bridge.rest.model.TaskReference;
 import org.sagebionetworks.bridge.user.TestUserHelper;
 import org.sagebionetworks.bridge.user.TestUserHelper.TestUser;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
@@ -215,13 +216,20 @@ public class SchedulePlanTest {
             schedule2.setActivities(Lists.newArrayList(activity));
             
             Criteria criteria1 = new Criteria();
-            
-            criteria1.setMinAppVersions(new ImmutableMap.Builder<String, Integer>().put("Android", 2).build());
-            criteria1.setMaxAppVersions(new ImmutableMap.Builder<String, Integer>().put("Android", 5).build());
+            criteria1.setMinAppVersions(ImmutableMap.of("Android", 2));
+            criteria1.setMaxAppVersions(ImmutableMap.of("Android", 5));
+            criteria1.setAllOfGroups(ImmutableList.of());
+            criteria1.setNoneOfGroups(ImmutableList.of());
+            criteria1.setAllOfSubstudyIds(ImmutableList.of());
+            criteria1.setNoneOfSubstudyIds(ImmutableList.of());
             
             Criteria criteria2 = new Criteria();
-            criteria2.setMinAppVersions(new ImmutableMap.Builder<String, Integer>().put("Android", 6).build());
-            criteria2.setMaxAppVersions(new ImmutableMap.Builder<String, Integer>().put("Android", 10).build());
+            criteria2.setMinAppVersions(ImmutableMap.of("Android", 6));
+            criteria2.setMaxAppVersions(ImmutableMap.of("Android", 10));
+            criteria2.setAllOfGroups(ImmutableList.of());
+            criteria2.setNoneOfGroups(ImmutableList.of());
+            criteria2.setAllOfSubstudyIds(ImmutableList.of());
+            criteria2.setNoneOfSubstudyIds(ImmutableList.of());
             
             ScheduleCriteria scheduleCriteria1 = new ScheduleCriteria();
             scheduleCriteria1.setCriteria(criteria1);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduledActivityAutoResolutionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduledActivityAutoResolutionTest.java
@@ -332,8 +332,8 @@ public class ScheduledActivityAutoResolutionTest {
     private GuidCreatedOnVersionHolder createSimpleSurvey() throws Exception {
         Constraints constraints = new IntegerConstraints().dataType(DataType.INTEGER);
         SurveyElement surveyQuestion = new SurveyQuestion().constraints(constraints)
-                .prompt("Pick a Number").uiHint(UIHint.NUMBERFIELD).identifier("test-survey-q")
-                .type("SurveyQuestion");
+                .prompt("Pick a Number").uiHint(UIHint.NUMBERFIELD).identifier("test-survey-q");
+        Tests.setVariableValueInObject(surveyQuestion, "type", "SurveyQuestion");
         Survey survey = new Survey().name(surveyId).identifier(surveyId).addElementsItem(surveyQuestion);
         return surveyApi.createSurvey(survey).execute().body();
     }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SubpopulationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SubpopulationTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 
 import org.junit.After;
@@ -100,7 +101,13 @@ public class SubpopulationTest {
         assertNotNull(findByName(subpops.getItems(), "Default Consent Group"));
         
         Criteria criteria = new Criteria();
-        criteria.getMinAppVersions().put("Android", 10);
+        // Set empty collections so this object is equal to the object returned by the API
+        criteria.setAllOfGroups(ImmutableList.of());
+        criteria.setNoneOfGroups(ImmutableList.of());
+        criteria.setAllOfSubstudyIds(ImmutableList.of());
+        criteria.setNoneOfSubstudyIds(ImmutableList.of());
+        criteria.setMaxAppVersions(ImmutableMap.of());        
+        criteria.setMinAppVersions(ImmutableMap.of("Android", 10));
         
         // Create a new one
         subpop1 = new Subpopulation();
@@ -191,15 +198,15 @@ public class SubpopulationTest {
         user.signOut();
         try {
             Criteria criteria1 = new Criteria();
-            criteria1.getMinAppVersions().put("Android", 0);
-            criteria1.getMaxAppVersions().put("Android", 10);
+            criteria1.setMinAppVersions(ImmutableMap.of("Android", 0));
+            criteria1.setMaxAppVersions(ImmutableMap.of("Android", 10));
             subpop1 = new Subpopulation();
             subpop1.setName("Consent Group 1");
             subpop1.setCriteria(criteria1);
             subpop1.setRequired(true);
             
             Criteria criteria2 = new Criteria();
-            criteria2.getMinAppVersions().put("Android", 11);
+            criteria2.setMinAppVersions(ImmutableMap.of("Android", 11));
             subpop2 = new Subpopulation();
             subpop2.setName("Consent Group 2");
             subpop2.setCriteria(criteria2);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveySchemaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveySchemaTest.java
@@ -259,7 +259,7 @@ public class SurveySchemaTest {
         q1.setUiHint(UIHint.CHECKBOX);
         q1.setPrompt("Choose one or more or fewer");
         q1.setConstraints(con);
-        q1.setType("SurveyQuestion");
+        Tests.setVariableValueInObject(q1, "type", "SurveyQuestion");
         
         BooleanConstraints bc = new BooleanConstraints();
         bc.setDataType(DataType.BOOLEAN);
@@ -270,7 +270,7 @@ public class SurveySchemaTest {
         q2.setPrompt("Yes or No?");
         bc.setDataType(DataType.BOOLEAN);
         q2.setConstraints(bc);
-        q2.setType("SurveyQuestion");
+        Tests.setVariableValueInObject(q2, "type", "SurveyQuestion");
 
         Survey survey = new Survey();
         survey.setName(SURVEY_NAME);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import retrofit2.Call;
@@ -635,7 +636,7 @@ public class SurveyTest {
         screen.setTitle("Title");
         screen.setPrompt("Prompt");
         screen.setPromptDetail("Prompt detail");
-        screen.setType("SurveyInfoScreen");
+        Tests.setVariableValueInObject(screen, "type", "SurveyInfoScreen");
         
         Image image = new Image();
         image.setSource("https://pbs.twimg.com/profile_images/1642204340/ReferencePear_400x400.PNG");
@@ -652,7 +653,7 @@ public class SurveyTest {
         StringConstraints sc = new StringConstraints();
         sc.setDataType(DataType.STRING);
         question.setConstraints(sc);
-        question.setType("SurveyQuestion");
+        Tests.setVariableValueInObject(question, "type", "SurveyQuestion");
         survey.getElements().add(question);
         
         GuidCreatedOnVersionHolder keys = createSurvey(surveysApi, survey);
@@ -754,8 +755,8 @@ public class SurveyTest {
         question.setPrompt("Prompt");
         question.setUiHint(UIHint.TEXTFIELD);
         question.setConstraints(constraints);
-        question.setType("SurveyQuestion");
-        question.getAfterRules().add(rule); // end survey
+        Tests.setVariableValueInObject(question, "type", "SurveyQuestion");
+        question.setAfterRules(ImmutableList.of(rule)); // end survey
         survey.getElements().add(question);
         
         GuidCreatedOnVersionHolder keys = createSurvey(surveysApi, survey);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/TestSurvey.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/TestSurvey.java
@@ -103,7 +103,7 @@ public class TestSurvey {
         return rule;
     }
     
-    public static Survey getSurvey(Class<?> cls) {
+    public static Survey getSurvey(Class<?> cls) throws Exception {
         Survey survey = new Survey();
         
         SurveyQuestion multiValueQuestion = new SurveyQuestion();
@@ -127,7 +127,7 @@ public class TestSurvey {
         multiValueQuestion.setPrompt("How do you feel today?");
         multiValueQuestion.setIdentifier(MULTIVALUE_ID);
         multiValueQuestion.setUiHint(UIHint.LIST);
-        multiValueQuestion.setType("SurveyQuestion");
+        Tests.setVariableValueInObject(multiValueQuestion, "type", "SurveyQuestion");
         
         SurveyQuestion stringQuestion = new SurveyQuestion();
         StringConstraints c = new StringConstraints();
@@ -142,7 +142,7 @@ public class TestSurvey {
         stringQuestion.setIdentifier(STRING_ID);
         stringQuestion.setConstraints(c);
         stringQuestion.setUiHint(UIHint.TEXTFIELD);
-        stringQuestion.setType("SurveyQuestion");
+        Tests.setVariableValueInObject(stringQuestion, "type", "SurveyQuestion");
         
         SurveyQuestion booleanQuestion = new SurveyQuestion();
         BooleanConstraints c1 = new BooleanConstraints();
@@ -151,7 +151,7 @@ public class TestSurvey {
         booleanQuestion.setIdentifier(BOOLEAN_ID);
         booleanQuestion.setConstraints(c1);
         booleanQuestion.setUiHint(UIHint.CHECKBOX);
-        booleanQuestion.setType("SurveyQuestion");
+        Tests.setVariableValueInObject(booleanQuestion, "type", "SurveyQuestion");
         
         SurveyQuestion dateQuestion = new SurveyQuestion();
         DateConstraints c2 = new DateConstraints();
@@ -163,7 +163,7 @@ public class TestSurvey {
         dateQuestion.setIdentifier(DATE_ID);
         dateQuestion.setConstraints(c2);
         dateQuestion.setUiHint(UIHint.DATEPICKER);
-        dateQuestion.setType("SurveyQuestion");
+        Tests.setVariableValueInObject(dateQuestion, "type", "SurveyQuestion");
         
         SurveyQuestion dateTimeQuestion = new SurveyQuestion();
         DateTimeConstraints c3 = new DateTimeConstraints();
@@ -175,7 +175,7 @@ public class TestSurvey {
         dateTimeQuestion.setIdentifier(DATETIME_ID);
         dateTimeQuestion.setConstraints(c3);
         dateTimeQuestion.setUiHint(UIHint.DATETIMEPICKER);
-        dateTimeQuestion.setType("SurveyQuestion");
+        Tests.setVariableValueInObject(dateTimeQuestion, "type", "SurveyQuestion");
         
         SurveyQuestion decimalQuestion = new SurveyQuestion();
         DecimalConstraints c4 = new DecimalConstraints();
@@ -188,7 +188,7 @@ public class TestSurvey {
         decimalQuestion.setIdentifier(DECIMAL_ID);
         decimalQuestion.setConstraints(c4);
         decimalQuestion.setUiHint(UIHint.NUMBERFIELD);
-        decimalQuestion.setType("SurveyQuestion");
+        Tests.setVariableValueInObject(decimalQuestion, "type", "SurveyQuestion");
         
         SurveyQuestion durationQuestion = new SurveyQuestion();
         DurationConstraints c5 = new DurationConstraints();
@@ -201,7 +201,7 @@ public class TestSurvey {
         durationQuestion.setIdentifier(DURATION_ID);
         durationQuestion.setConstraints(c5);
         durationQuestion.setUiHint(UIHint.SLIDER);
-        durationQuestion.setType("SurveyQuestion");
+        Tests.setVariableValueInObject(durationQuestion, "type", "SurveyQuestion");
         
         SurveyRule rule1 = rule(Operator.LE, "2", "phone_number");
         SurveyRule rule2 = rule(Operator.DE, null, "phone_number");
@@ -217,8 +217,8 @@ public class TestSurvey {
         integerQuestion.setIdentifier(INTEGER_ID);
         integerQuestion.setConstraints(c6);
         integerQuestion.setUiHint(UIHint.NUMBERFIELD);
-        integerQuestion.setType("SurveyQuestion");
         integerQuestion.setAfterRules(Lists.newArrayList(rule1, rule2));
+        Tests.setVariableValueInObject(integerQuestion, "type", "SurveyQuestion");
         
         SurveyQuestion timeQuestion = new SurveyQuestion();
         TimeConstraints c7 = new TimeConstraints();
@@ -227,7 +227,7 @@ public class TestSurvey {
         timeQuestion.setIdentifier(TIME_ID);
         timeQuestion.setConstraints(c7);
         timeQuestion.setUiHint(UIHint.TIMEPICKER);
-        timeQuestion.setType("SurveyQuestion");
+        Tests.setVariableValueInObject(timeQuestion, "type", "SurveyQuestion");
 
         SurveyQuestion bloodpressureQuestion = new SurveyQuestion();
         BloodPressureConstraints c8 = new BloodPressureConstraints();
@@ -237,7 +237,7 @@ public class TestSurvey {
         bloodpressureQuestion.setPrompt("What is your blood pressure?");
         bloodpressureQuestion.setIdentifier(BLOODPRESSURE_ID);
         bloodpressureQuestion.setUiHint(UIHint.BLOODPRESSURE);
-        bloodpressureQuestion.setType("SurveyQuestion");
+        Tests.setVariableValueInObject(bloodpressureQuestion, "type", "SurveyQuestion");
 
         SurveyQuestion heightQuestion = new SurveyQuestion();
         HeightConstraints c9 = new HeightConstraints();
@@ -248,7 +248,7 @@ public class TestSurvey {
         heightQuestion.setPrompt("What is your height?");
         heightQuestion.setIdentifier(HEIGHT_ID);
         heightQuestion.setUiHint(UIHint.HEIGHT);
-        heightQuestion.setType("SurveyQuestion");
+        Tests.setVariableValueInObject(heightQuestion, "type", "SurveyQuestion");
 
         SurveyQuestion weightQuestion = new SurveyQuestion();
         WeightConstraints c10 = new WeightConstraints();
@@ -259,7 +259,7 @@ public class TestSurvey {
         weightQuestion.setPrompt("What is your weight?");
         weightQuestion.setIdentifier(WEIGHT_ID);
         weightQuestion.setUiHint(UIHint.WEIGHT);
-        weightQuestion.setType("SurveyQuestion");
+        Tests.setVariableValueInObject(weightQuestion, "type", "SurveyQuestion");
         
         SurveyQuestion yearMonthQuestion = new SurveyQuestion();
         YearMonthConstraints c11 = new YearMonthConstraints();
@@ -271,7 +271,7 @@ public class TestSurvey {
         yearMonthQuestion.setPrompt("What year and month?");
         yearMonthQuestion.setIdentifier(YEARMONTH_ID);
         yearMonthQuestion.setUiHint(UIHint.YEARMONTH);
-        yearMonthQuestion.setType("SurveyQuestion");
+        Tests.setVariableValueInObject(yearMonthQuestion, "type", "SurveyQuestion");
 
         SurveyQuestion postalCodeQuestion = new SurveyQuestion();
         PostalCodeConstraints pcc = new PostalCodeConstraints();
@@ -281,7 +281,7 @@ public class TestSurvey {
         postalCodeQuestion.setPrompt("Postal code?");
         postalCodeQuestion.setIdentifier(POSTALCODE_ID);
         postalCodeQuestion.setUiHint(UIHint.POSTALCODE);
-        postalCodeQuestion.setType("SurveyQuestion");
+        Tests.setVariableValueInObject(postalCodeQuestion, "type", "SurveyQuestion");
         
         survey.setName(cls.getSimpleName() + " Survey");
         survey.setIdentifier(Tests.randomIdentifier(cls));

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
@@ -230,14 +230,14 @@ public class Tests {
         study.setConsentNotificationEmail("bridge-testing+test2@sagebase.org");
         study.setTechnicalEmail("test3@test.com");
         study.setUsesCustomExportSchedule(true);
-        study.getUserProfileAttributes().add("new_profile_attribute");
+        study.setUserProfileAttributes(Lists.newArrayList("new_profile_attribute"));
         study.setTaskIdentifiers(Lists.newArrayList("taskA")); // setting it differently just for the heck of it 
         study.setDataGroups(Lists.newArrayList("beta_users", "production_users"));
-        study.setResetPasswordTemplate(Tests.TEST_RESET_PASSWORD_TEMPLATE);
-        study.setVerifyEmailTemplate(Tests.TEST_VERIFY_EMAIL_TEMPLATE);
-        study.setEmailSignInTemplate(Tests.TEST_EMAIL_SIGNIN_TEMPLATE);
-        study.setAccountExistsTemplate(Tests.TEST_ACCOUNT_EXISTS_TEMPLATE);
-        study.setAppInstallLinkTemplate(Tests.APP_INSTALL_LINK_TEMPLATE);
+        study.setResetPasswordTemplate(TEST_RESET_PASSWORD_TEMPLATE);
+        study.setVerifyEmailTemplate(TEST_VERIFY_EMAIL_TEMPLATE);
+        study.setEmailSignInTemplate(TEST_EMAIL_SIGNIN_TEMPLATE);
+        study.setAccountExistsTemplate(TEST_ACCOUNT_EXISTS_TEMPLATE);
+        study.setAppInstallLinkTemplate(APP_INSTALL_LINK_TEMPLATE);
         study.setResetPasswordSmsTemplate(RESET_PASSWORD_SMS_TEMPLATE);
         study.setPhoneSignInSmsTemplate(PHONE_SIGNIN_SMS_TEMPLATE);
         study.setAppInstallLinkSmsTemplate(APP_INSTALL_LINK_SMS_TEMPLATE);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
@@ -173,7 +173,7 @@ public class UploadSchemaTest {
         assertSchemaFilledIn(workerSchemaV2);
 
         UploadSchema workerSchemaV2MinusStudyId = copy(null, workerSchemaV2);
-        workerSchemaV2MinusStudyId.setStudyId(null);
+        Tests.setVariableValueInObject(workerSchemaV2MinusStudyId, "studyId", null);
         
         assertEquals(updatedSchemaV2, workerSchemaV2MinusStudyId);
 
@@ -479,7 +479,7 @@ public class UploadSchemaTest {
         schemaV2.setRevision(fetchedSchemaV1.getRevision());
         schemaV2.setSchemaId(fetchedSchemaV1.getSchemaId());
         schemaV2.setSchemaType(fetchedSchemaV1.getSchemaType());
-        schemaV2.setStudyId(fetchedSchemaV1.getStudyId());
+        Tests.setVariableValueInObject(schemaV2, "studyId", fetchedSchemaV1.getStudyId());
         schemaV2.setSurveyGuid(fetchedSchemaV1.getSurveyGuid());
         schemaV2.setSurveyCreatedOn(fetchedSchemaV1.getSurveyCreatedOn());
         schemaV2.setVersion(fetchedSchemaV1.getVersion());
@@ -605,11 +605,13 @@ public class UploadSchemaTest {
         destination.setRevision(source.getRevision());
         destination.setSchemaId(source.getSchemaId());
         destination.setSchemaType(source.getSchemaType());
-        destination.setStudyId(source.getStudyId());
+        Tests.setVariableValueInObject(destination, "studyId", source.getStudyId());
         destination.setSurveyCreatedOn(source.getSurveyCreatedOn());
         destination.setSurveyGuid(source.getSurveyGuid());
         destination.setDeleted(source.isDeleted());
         destination.setVersion(source.getVersion());
+        destination.setMinAppVersions(source.getMinAppVersions());
+        destination.setMaxAppVersions(source.getMaxAppVersions());
         Tests.setVariableValueInObject(destination, "type", source.getType());
         return destination;
     }


### PR DESCRIPTION
Only a couple of changes, ultimately:
- need to use reflection to set the type property, which is only needed so that objects test equal in equality tests when you're testing locally constructed objects with objects that are returned from the server;
- need to set collections which are now often null instead of empty after object construction (to avoid NPEs or to make equality tests pass).