### PR TITLE
Reduce the use of pre-created accounts to a single administrator.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>BridgeIntegTestUtils</artifactId>
-            <version>1.0.4</version>
+            <version>1.0.6</version>
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
@@ -199,11 +199,11 @@ public class ParticipantsTest {
         DateTime oldest = summaries.getItems().get(0).getCreatedOn();
         DateTime newest = summaries.getItems().get(summaries.getItems().size()-1).getCreatedOn();
         
-        // Well we know there's at least two accounts... the admin and the researcher.
+        // Well we know there's at least the bootstrap admin account
         assertEquals(0, summaries.getRequestParams().getOffsetBy().intValue());
         assertEquals(10, summaries.getRequestParams().getPageSize().intValue());
         assertTrue(summaries.getItems().size() <= summaries.getTotal());
-        assertTrue(summaries.getItems().size() > 2);
+        assertTrue(summaries.getItems().size() > 1);
         
         AccountSummary summary = summaries.getItems().get(0);
         assertNotNull(summary.getCreatedOn());

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SessionRefreshTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SessionRefreshTest.java
@@ -3,27 +3,35 @@ package org.sagebionetworks.bridge.sdk.integration;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
 import org.sagebionetworks.bridge.rest.api.ParticipantsApi;
 import org.sagebionetworks.bridge.rest.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.user.TestUserHelper;
 
 import static org.junit.Assert.fail;
+import static org.sagebionetworks.bridge.rest.model.Role.DEVELOPER;
+import static org.sagebionetworks.bridge.util.IntegTestUtils.SHARED_STUDY_ID;
 
 import org.joda.time.DateTime;
 
 public class SessionRefreshTest {
     private static TestUserHelper.TestUser user;
+    private static TestUserHelper.TestUser sharedDeveloper;
 
     @BeforeClass
     public static void createUser() throws Exception {
         user = TestUserHelper.createAndSignInUser(SessionRefreshTest.class, false);
+        sharedDeveloper = TestUserHelper.createAndSignInUser(SessionRefreshTest.class, SHARED_STUDY_ID, DEVELOPER);
     }
 
     @AfterClass
     public static void deleteUser() throws Exception {
         if (user != null) {
             user.signOutAndDeleteUser();
+        }
+        if (sharedDeveloper != null) {
+            sharedDeveloper.signOutAndDeleteUser();
         }
     }
 
@@ -48,7 +56,6 @@ public class SessionRefreshTest {
     @Test
     public void testReauthenticationAcrossStudies() throws Exception {
         // Use developer from the Shared study to test across studies. Initial call succeeds.
-        TestUserHelper.TestUser sharedDeveloper = TestUserHelper.getSignedInSharedDeveloper();
         sharedDeveloper.getClient(ParticipantsApi.class).getUsersParticipantRecord(false).execute();
 
         // Sign user out.

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SharedModuleTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SharedModuleTest.java
@@ -3,10 +3,13 @@ package org.sagebionetworks.bridge.sdk.integration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.sagebionetworks.bridge.rest.model.Role.DEVELOPER;
+import static org.sagebionetworks.bridge.util.IntegTestUtils.SHARED_STUDY_ID;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.joda.time.DateTime;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -44,10 +47,10 @@ public class SharedModuleTest {
     private Survey localSurvey;
 
     @BeforeClass
-    public static void beforeClass() {
+    public static void beforeClass() throws Exception {
         admin = TestUserHelper.getSignedInAdmin();
-        apiDeveloper = TestUserHelper.getSignedInApiDeveloper();
-        sharedDeveloper = TestUserHelper.getSignedInSharedDeveloper();
+        apiDeveloper = TestUserHelper.createAndSignInUser(SharedModuleTest.class, false, DEVELOPER);
+        sharedDeveloper = TestUserHelper.createAndSignInUser(SharedModuleTest.class, SHARED_STUDY_ID, DEVELOPER);
     }
 
     @Before
@@ -58,6 +61,16 @@ public class SharedModuleTest {
         localSchema = null;
         sharedSurvey = null;
         localSurvey = null;
+    }
+    
+    @AfterClass
+    public static void afterClass() throws Exception {
+        if (apiDeveloper != null) {
+            apiDeveloper.signOutAndDeleteUser();
+        }
+        if (sharedDeveloper != null) {
+            sharedDeveloper.signOutAndDeleteUser();
+        }
     }
 
     @After

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.sagebionetworks.bridge.rest.model.Role.DEVELOPER;
 import static org.sagebionetworks.bridge.sdk.integration.TestSurvey.BLOODPRESSURE_ID;
 import static org.sagebionetworks.bridge.sdk.integration.TestSurvey.BOOLEAN_ID;
 import static org.sagebionetworks.bridge.sdk.integration.TestSurvey.DATETIME_ID;
@@ -20,6 +21,7 @@ import static org.sagebionetworks.bridge.sdk.integration.TestSurvey.STRING_ID;
 import static org.sagebionetworks.bridge.sdk.integration.TestSurvey.TIME_ID;
 import static org.sagebionetworks.bridge.sdk.integration.TestSurvey.WEIGHT_ID;
 import static org.sagebionetworks.bridge.sdk.integration.TestSurvey.YEARMONTH_ID;
+import static org.sagebionetworks.bridge.util.IntegTestUtils.SHARED_STUDY_ID;
 import static org.sagebionetworks.bridge.sdk.integration.TestSurvey.POSTALCODE_ID;
 
 import java.io.IOException;
@@ -104,10 +106,10 @@ public class SurveyTest {
     
     private static final String SURVEY_NAME = "dummy-survey-name";
 
-    //private static TestUser admin;
     private static TestUser developer;
     private static TestUser user;
     private static TestUser worker;
+    private static TestUser sharedDeveloper;
     private static SharedModulesApi sharedDeveloperModulesApi;
     private static SurveysApi sharedSurveysApi;
     private static ForAdminsApi adminsApi;
@@ -126,7 +128,7 @@ public class SurveyTest {
         user = TestUserHelper.createAndSignInUser(SurveyTest.class, true);
         worker = TestUserHelper.createAndSignInUser(SurveyTest.class, false, Role.WORKER);
 
-        TestUserHelper.TestUser sharedDeveloper = TestUserHelper.getSignedInSharedDeveloper();
+        sharedDeveloper = TestUserHelper.createAndSignInUser(SurveyTest.class, SHARED_STUDY_ID, DEVELOPER);        
         sharedDeveloperModulesApi = sharedDeveloper.getClient(SharedModulesApi.class);
         sharedSurveysApi = sharedDeveloper.getClient(SurveysApi.class);
     }
@@ -170,6 +172,13 @@ public class SurveyTest {
     public static void deleteWorker() throws Exception {
         if (worker != null) {
             worker.signOutAndDeleteUser();
+        }
+    }
+    
+    @AfterClass
+    public static void deleteSharedDeveloper() throws Exception {
+        if (sharedDeveloper != null) {
+            sharedDeveloper.signOutAndDeleteUser();
         }
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/TemplateTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/TemplateTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.sdk.integration;
 
-import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -8,10 +7,6 @@ import static org.junit.Assert.fail;
 import static org.sagebionetworks.bridge.rest.model.Role.DEVELOPER;
 import static org.sagebionetworks.bridge.rest.model.TemplateType.EMAIL_ACCOUNT_EXISTS;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import org.junit.After;

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
@@ -6,6 +6,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.sagebionetworks.bridge.rest.model.Role.DEVELOPER;
+import static org.sagebionetworks.bridge.rest.model.Role.WORKER;
+import static org.sagebionetworks.bridge.util.IntegTestUtils.SHARED_STUDY_ID;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -35,7 +38,6 @@ import org.sagebionetworks.bridge.rest.exceptions.ConcurrentModificationExceptio
 import org.sagebionetworks.bridge.rest.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.rest.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.rest.exceptions.UnauthorizedException;
-import org.sagebionetworks.bridge.rest.model.Role;
 import org.sagebionetworks.bridge.rest.model.SharedModuleMetadata;
 import org.sagebionetworks.bridge.rest.model.UploadFieldDefinition;
 import org.sagebionetworks.bridge.rest.model.UploadFieldType;
@@ -52,6 +54,7 @@ public class UploadSchemaTest {
     private static TestUserHelper.TestUser developer;
     private static TestUserHelper.TestUser user;
     private static TestUserHelper.TestUser worker;
+    private static TestUserHelper.TestUser sharedDeveloper;
     private static ForAdminsApi adminApi;
     private static UploadSchemasApi devUploadSchemasApi;
     private static ForWorkersApi workerUploadSchemasApi;
@@ -63,10 +66,10 @@ public class UploadSchemaTest {
     @BeforeClass
     public static void beforeClass() throws Exception {
         TestUserHelper.TestUser admin = TestUserHelper.getSignedInAdmin();
-        developer = TestUserHelper.createAndSignInUser(UploadSchemaTest.class, false, Role.DEVELOPER);
+        developer = TestUserHelper.createAndSignInUser(UploadSchemaTest.class, false, DEVELOPER);
         user = TestUserHelper.createAndSignInUser(UploadSchemaTest.class, true);
-        worker = TestUserHelper.createAndSignInUser(UploadSchemaTest.class, false, Role.WORKER);
-        TestUserHelper.TestUser sharedDeveloper = TestUserHelper.getSignedInSharedDeveloper();
+        worker = TestUserHelper.createAndSignInUser(UploadSchemaTest.class, false, WORKER);
+        sharedDeveloper = TestUserHelper.createAndSignInUser(UploadSchemaTest.class, SHARED_STUDY_ID, DEVELOPER);
         sharedDeveloperModulesApi = sharedDeveloper.getClient(SharedModulesApi.class);
 
         adminApi = admin.getClient(ForAdminsApi.class);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
@@ -113,6 +113,13 @@ public class UploadSchemaTest {
             worker.signOutAndDeleteUser();
         }
     }
+    
+    @AfterClass
+    public static void deleteSharedDeveloper() throws Exception {
+        if (sharedDeveloper != null) {
+            sharedDeveloper.signOutAndDeleteUser();
+        }
+    }
 
     @Test
     public void testDeleteWithSharedModule() throws Exception {


### PR DESCRIPTION
BRIDGE-2086. This required some changes in the BridgeIntegTestUtils package as well, but these were minor. This in turn allows our bootstrapping documentation to be a lot simpler, so I have updated the BridgeServer2 wiki page accordingly. 