### PR TITLE
Bump version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.19.8</version>
+            <version>0.19.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Necessary to pick up the defaultTemplate map, otherwise integration tests will keep breaking studies.