### PR TITLE
Very marking survey options as exclusive works

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.19.22</version>
+            <version>0.19.23</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
@@ -311,7 +311,7 @@ public class SurveyTest {
         assertTrue(multiValueConstraints.isRequired());        
         assertEquals("MultiValueConstraints", multiValueConstraints.getType());
         List<SurveyQuestionOption> options = multiValueConstraints.getEnumeration();
-        assertEquals(5, options.size());
+        assertEquals(6, options.size());
         SurveyQuestionOption option = options.get(0);
         assertEquals("Terrible", option.getLabel());
         assertEquals("Terrible Detail", option.getDetail());

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
@@ -312,13 +312,15 @@ public class SurveyTest {
         assertEquals("MultiValueConstraints", multiValueConstraints.getType());
         List<SurveyQuestionOption> options = multiValueConstraints.getEnumeration();
         assertEquals(6, options.size());
-        SurveyQuestionOption option = options.get(0);
-        assertEquals("Terrible", option.getLabel());
-        assertEquals("Terrible Detail", option.getDetail());
-        assertEquals("1", option.getValue());
+
+        SurveyQuestionOption option = options.get(5);
+        assertEquals("None of the above", option.getLabel());
+        assertEquals("nota", option.getDetail());
+        assertEquals("0", option.getValue());
         assertEquals("http://terrible.svg", option.getImage().getSource());
         assertEquals(new Integer(600), option.getImage().getWidth());
         assertEquals(new Integer(300), option.getImage().getHeight());
+        assertTrue(option.isExclusive());
         
         // String question
         SurveyQuestion stringQuestion = getQuestion(survey, STRING_ID);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/TestSurvey.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/TestSurvey.java
@@ -88,12 +88,13 @@ public class TestSurvey {
         return image;
     }
     
-    private static SurveyQuestionOption option(String label, String detail, String value, Image image) {
+    private static SurveyQuestionOption option(String label, String detail, String value, Image image, boolean exclusive) {
         SurveyQuestionOption option = new SurveyQuestionOption();
         option.setLabel(label);
         option.setDetail(detail);
         option.setValue(value);
         option.setImage(image);
+        option.setExclusive(exclusive);
         return option;
     }
     
@@ -116,11 +117,12 @@ public class TestSurvey {
         Image great = image("http://great.svg", 600, 300);
         MultiValueConstraints mvc = new MultiValueConstraints();
         List<SurveyQuestionOption> options = Lists.newArrayList(
-                option("Terrible", "Terrible Detail", "1", terrible), 
-                option("Poor", "Poor Detail", "2", poor),
-                option("OK", "OK Detail", "3", ok), 
-                option("Good", "Good Detail", "4", good),
-                option("Great", "Great Detail", "5", great));
+                option("Terrible", "Terrible Detail", "1", terrible, false), 
+                option("Poor", "Poor Detail", "2", poor, false),
+                option("OK", "OK Detail", "3", ok, false), 
+                option("Good", "Good Detail", "4", good, false),
+                option("Great", "Great Detail", "5", great, false),
+                option("None of the above", "nota", "0", null, true));
         mvc.setEnumeration(options);
         mvc.setAllowOther(false);
         mvc.setAllowMultiple(true);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/TestSurvey.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/TestSurvey.java
@@ -122,7 +122,7 @@ public class TestSurvey {
                 option("OK", "OK Detail", "3", ok, false), 
                 option("Good", "Good Detail", "4", good, false),
                 option("Great", "Great Detail", "5", great, false),
-                option("None of the above", "nota", "0", null, true));
+                option("None of the above", "nota", "0", terrible, true));
         mvc.setEnumeration(options);
         mvc.setAllowOther(false);
         mvc.setAllowMultiple(true);


### PR DESCRIPTION
The survey engine will deselect all other options when an exclusive option is checked, and probably disable them as well. It is used for a "none of the above" option which is not the same as an "other" option.