### PR TITLE
Bump version of test utilities to clean up accounts in the shared study.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>BridgeIntegTestUtils</artifactId>
-            <version>1.0.8</version>
+            <version>1.0.9</version>
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>


### PR DESCRIPTION
Shared utilities have been updated to check and change the admin's study before deleting users in the shared study (these were being left behind after test runs).