### PR TITLE
These tests were not doing what they appeared to be doing

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SelfStudyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SelfStudyTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 
 import org.sagebionetworks.bridge.rest.api.StudiesApi;
 import org.sagebionetworks.bridge.rest.exceptions.UnauthorizedException;
-import org.sagebionetworks.bridge.rest.model.Role;
 import org.sagebionetworks.bridge.rest.model.Study;
 import org.sagebionetworks.bridge.user.TestUserHelper;
 import org.sagebionetworks.bridge.user.TestUserHelper.TestUser;


### PR DESCRIPTION
We needed to separate the scoped developer out because in some tests, the scoped developer was being used to manipulate reports from a user in a different substudy. This was only working because of a server bug where this scoped developer could retrieve the account... this test has been fixed to reflect the fix in the server code.