### PR TITLE
add MutableHolder.toString()

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
@@ -1610,6 +1610,15 @@ public class SurveyTest {
                 Objects.equals(guid, other.guid) &&
                 Objects.equals(version, other.version);
         }
+
+        @Override
+        public String toString() {
+            return "MutableHolder{" +
+                    "guid='" + guid + '\'' +
+                    ", createdOn=" + createdOn +
+                    ", version=" + version +
+                    '}';
+        }
     }
     
     // Helper methods to ensure we always record these calls for cleanup


### PR DESCRIPTION
Tests uncovered a weird test logging issue:

```
java.lang.AssertionError: Survey contains expected key: class GuidCreatedOnVersionHolder {
    guid: null
    createdOn: null
    version: null
    type: null
}
```

The keys are not actually null. This occurs because we are using a test class called MutableHolder, which subclasses GuidCreatedOnVersionHolder, but doesn't override toString(). So the parent toString() is called, and it sees all the members are null and prints accordingly. There's not really any good reason for MutableHolder to subclass GuidCreatedOnVersionHolder. (In fact, it overrides everything _except_ toString().) However, it's used in so many places that it's hard to change at this point. Easiest thing to do is to just override toString() and file a Jira to refactor this.

Filed https://sagebionetworks.jira.com/browse/BRIDGE-2797 to track the refactoring.