### PR TITLE
AssessmentTest and ReportTest do not clean up test accounts; other test fixes

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AssessmentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AssessmentTest.java
@@ -63,18 +63,23 @@ public class AssessmentTest {
     
     @Before
     public void before() throws Exception {
+        id = randomIdentifier(AssessmentTest.class);
+        markerTag = "test:" + randomIdentifier(AssessmentTest.class);
+
         admin = TestUserHelper.getSignedInAdmin();
         SubstudiesApi subApi = admin.getClient(SubstudiesApi.class);
         
         // Getting ahead of our skis here, as we haven't refactored substudies to be organizations
         // and we're already using them that way.
-        Substudy org = subApi.getSubstudy(SUBSTUDY_ID_1).execute().body();
-        if (org == null) {
+        try {
+            subApi.getSubstudy(SUBSTUDY_ID_1).execute();
+        } catch (EntityNotFoundException ex) {
             Substudy substudy = new Substudy().id(SUBSTUDY_ID_1).name(SUBSTUDY_ID_1);
             subApi.createSubstudy(substudy).execute();
         }
-        org = subApi.getSubstudy(SUBSTUDY_ID_2).execute().body();
-        if (org == null) {
+        try {
+            subApi.getSubstudy(SUBSTUDY_ID_2).execute().body();
+        } catch (EntityNotFoundException ex) {
             Substudy substudy = new Substudy().id(SUBSTUDY_ID_2).name(SUBSTUDY_ID_2);
             subApi.createSubstudy(substudy).execute();
         }
@@ -85,14 +90,15 @@ public class AssessmentTest {
                 .withSubstudyIds(ImmutableSet.of(SUBSTUDY_ID_2)).createAndSignInUser();
         assessmentApi = developer.getClient(AssessmentsApi.class);
         badDevApi = otherDeveloper.getClient(AssessmentsApi.class);
-        id = randomIdentifier(AssessmentTest.class);
-        markerTag = "test:" + randomIdentifier(AssessmentTest.class);
     }
     
     @After
     public void after() throws IOException {
         if (developer != null) {
             developer.signOutAndDeleteUser();            
+        }
+        if (otherDeveloper != null) {
+            otherDeveloper.signOutAndDeleteUser();
         }
         TestUser admin = TestUserHelper.getSignedInAdmin();
         AssessmentsApi api = admin.getClient(AssessmentsApi.class);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ReportTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ReportTest.java
@@ -103,6 +103,8 @@ public class ReportTest {
         studyScopedDeveloper = new TestUserHelper.Builder(ReportTest.class).withRoles(DEVELOPER)
                 .withSubstudyIds(ImmutableSet.of(substudy1.getId())).createAndSignInUser();
 
+        worker = TestUserHelper.createAndSignInUser(ReportTest.class, false, WORKER, RESEARCHER);
+
         // Worker test needs to be able to get healthcode.
         ForSuperadminsApi superadminApi = admin.getClient(ForSuperadminsApi.class);
         Study study = superadminApi.getStudy(STUDY_ID).execute().body();
@@ -209,7 +211,6 @@ public class ReportTest {
     @Test
     public void workerCanCrudParticipantReportByDate() throws Exception {
         user = TestUserHelper.createAndSignInUser(ReportTest.class, true);
-        worker = TestUserHelper.createAndSignInUser(ReportTest.class, false, WORKER, RESEARCHER);
 
         String healthCode = worker.getClient(ParticipantsApi.class).getParticipantById(user.getSession().getId(),
                 false).execute().body().getHealthCode();
@@ -250,8 +251,7 @@ public class ReportTest {
     @Test
     public void workerCanCrudParticipantReportByDateTime() throws Exception {
         user = TestUserHelper.createAndSignInUser(ReportTest.class, true);
-        worker = TestUserHelper.createAndSignInUser(ReportTest.class, false, WORKER, RESEARCHER);
-        
+
         String healthCode = worker.getClient(ParticipantsApi.class).getParticipantById(user.getSession().getId(),
                 false).execute().body().getHealthCode();
         assertNotNull(healthCode);
@@ -524,9 +524,7 @@ public class ReportTest {
     
     @Test
     public void participantReportsNotVisibleOutsideOfSubstudy() throws Exception {
-        worker = TestUserHelper.createAndSignInUser(ReportTest.class, true, WORKER, RESEARCHER);
-        
-        // It would seem to be dumb to create reports for a participant that are associated to substudies such that the 
+        // It would seem to be dumb to create reports for a participant that are associated to substudies such that the
         // user will not be able to see them. Nevertheless, if it happens, we enforce visibility constraints.
         substudyScopedUser = new TestUserHelper.Builder(ReportTest.class).withConsentUser(true)
                 .withSubstudyIds(ImmutableSet.of(substudy2.getId())).createAndSignInUser();


### PR DESCRIPTION
AssessmentTest and ReportTest do not clean up test accounts. AssessmentTest was simply missing the code to clean up otherDeveloper. ReportTest has a static worker test user, but was overriding this in several tests and only cleaning it up once.

Other fixes:

* AssessmentTest now declares id and markerTag at the top, to prevent NullPointerException when before() fails.
* AssessmentTest calls getSubstudy, and if it returns null, it creates the substudy. However, getSubstudy throws if there's no substudy. This now uses a try-catch block.