### PR TITLE
Verify testing support.

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/CRCTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/CRCTest.java
@@ -154,7 +154,7 @@ public class CRCTest {
     
     @Test
     public void updateParticipantWithDeclined() throws IOException {
-     // This is a normal call but I have not bothered to create a Java SDK method for
+        // This is a normal call but I have not bothered to create a Java SDK method for
         // it. Don't set 'selected' as a data group, it'll trigger a call to our external
         // partner.
         StudyParticipant participant = adminUser.getClient(ParticipantsApi.class)


### PR DESCRIPTION
Verify that a test account, even when selected, does not call external partner and notifies the caller that it has done this.