### PR TITLE
Tests for new search options.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.20.9</version>
+            <version>0.20.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.20.8</version>
+            <version>0.20.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.20.10</version>
+            <version>0.20.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthTest.java
@@ -26,6 +26,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.rest.Config;
@@ -78,6 +79,7 @@ public class OAuthTest {
     }
     
     @Test(expected = EntityNotFoundException.class)
+    @Ignore
     public void requestOAuthAccessTokenExists() throws Exception {
         user = TestUserHelper.createAndSignInUser(OAuthTest.class, true);
         
@@ -88,6 +90,7 @@ public class OAuthTest {
     }
     
     @Test
+    @Ignore
     public void test() throws Exception {
         String synapseUserId = admin.getConfig().get("synapse.test.user.id");
         worker = TestUserHelper.createAndSignInUser(OAuthTest.class, true, 
@@ -132,6 +135,7 @@ public class OAuthTest {
     }
     
     @Test
+    @Ignore
     public void signInWithSynapseAccount() throws Exception {
         String synapseUserId = admin.getConfig().get("synapse.test.user.id");
         worker = TestUserHelper.createAndSignInUser(OAuthTest.class, true, 
@@ -196,6 +200,7 @@ public class OAuthTest {
     }
     
     @Test
+    @Ignore
     public void synapseUserCanSwitchBetweenStudies() throws Exception {
         // Going to use the shared app as well as the API app for this test.
         String synapseUserId = admin.getConfig().get("synapse.test.user.id");

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthTest.java
@@ -26,7 +26,6 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.rest.Config;
@@ -79,7 +78,6 @@ public class OAuthTest {
     }
     
     @Test(expected = EntityNotFoundException.class)
-    @Ignore
     public void requestOAuthAccessTokenExists() throws Exception {
         user = TestUserHelper.createAndSignInUser(OAuthTest.class, true);
         
@@ -90,7 +88,6 @@ public class OAuthTest {
     }
     
     @Test
-    @Ignore
     public void test() throws Exception {
         String synapseUserId = admin.getConfig().get("synapse.test.user.id");
         worker = TestUserHelper.createAndSignInUser(OAuthTest.class, true, 
@@ -135,7 +132,6 @@ public class OAuthTest {
     }
     
     @Test
-    @Ignore
     public void signInWithSynapseAccount() throws Exception {
         String synapseUserId = admin.getConfig().get("synapse.test.user.id");
         worker = TestUserHelper.createAndSignInUser(OAuthTest.class, true, 
@@ -200,7 +196,6 @@ public class OAuthTest {
     }
     
     @Test
-    @Ignore
     public void synapseUserCanSwitchBetweenStudies() throws Exception {
         // Going to use the shared app as well as the API app for this test.
         String synapseUserId = admin.getConfig().get("synapse.test.user.id");

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/OrganizationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/OrganizationTest.java
@@ -14,7 +14,6 @@ import com.google.common.collect.ImmutableSet;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.rest.api.OrganizationsApi;

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
@@ -58,6 +58,8 @@ public class Tests {
     public static final String PASSWORD = "P@ssword`1";
     public static final String SUBSTUDY_ID_1 = "substudy1";
     public static final String SUBSTUDY_ID_2 = "substudy2";
+    public static final String ORG_ID_1 = "org1";
+    public static final String ORG_ID_2 = "org2";
     public static final Phone PHONE = new Phone().number("9712486796").regionCode("US");
     public static final String NATIONAL_PHONE_FORMAT = "(971) 248-6796";
     public static final String SYNAPSE_USER_ID = "88888";


### PR DESCRIPTION
Just leaving org1 and org2 at the completion of this test because we will use them for the assessment tests once assessments are refactored.