### PR TITLE
Test filter of study enrollments by test account status

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.21.8</version>
+            <version>0.21.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/EnrollmentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/EnrollmentTest.java
@@ -79,10 +79,10 @@ public class EnrollmentTest {
             assertNull(enrollment.getWithdrawalNote());
             
             // Now shows up in paged api
-            EnrollmentDetailList list = studiesApi.getEnrollees(STUDY_ID_1, "enrolled", null, null).execute().body();
+            EnrollmentDetailList list = studiesApi.getEnrollees(STUDY_ID_1, "enrolled", false, null, null).execute().body();
             assertTrue(list.getItems().stream().anyMatch(e -> e.getParticipant().getIdentifier().equals(user.getUserId())));
             
-            list = studiesApi.getEnrollees(STUDY_ID_1, null, null, null).execute().body();
+            list = studiesApi.getEnrollees(STUDY_ID_1, null, false, null, null).execute().body();
             assertTrue(list.getItems().stream().anyMatch(e -> e.getParticipant().getIdentifier().equals(user.getUserId())));
             
             retValue = studiesApi.withdrawParticipant(STUDY_ID_1, user.getUserId(), 
@@ -95,7 +95,7 @@ public class EnrollmentTest {
             assertEquals(admin.getUserId(), retValue.getWithdrawnBy());
             assertEquals("Testing enrollment and withdrawal.", retValue.getWithdrawalNote());
             
-            list = studiesApi.getEnrollees(STUDY_ID_1, "enrolled", null, null).execute().body();
+            list = studiesApi.getEnrollees(STUDY_ID_1, "enrolled", false, null, null).execute().body();
             assertFalse(list.getItems().stream().anyMatch(e -> e.getParticipant().getIdentifier().equals(user.getUserId())));
             
             // This person is accessible via the external ID.
@@ -104,10 +104,20 @@ public class EnrollmentTest {
             assertEquals(user.getUserId(), participant.getId());
             
             // It is still in the paged API, despite being withdrawn.
-            list = studiesApi.getEnrollees(STUDY_ID_1, "withdrawn", null, null).execute().body();
+            list = studiesApi.getEnrollees(STUDY_ID_1, "withdrawn", false, null, null).execute().body();
             assertTrue(list.getItems().stream().anyMatch(e -> e.getParticipant().getIdentifier().equals(user.getUserId())));
             
-            list = studiesApi.getEnrollees(STUDY_ID_1, "all", null, null).execute().body();
+            list = studiesApi.getEnrollees(STUDY_ID_1, "all", false, null, null).execute().body();
+            assertTrue(list.getItems().stream().anyMatch(e -> e.getParticipant().getIdentifier().equals(user.getUserId())));
+            
+            // test the filter for test accounts
+            participant.addDataGroupsItem("test_user");
+            admin.getClient(ParticipantsApi.class).updateParticipant(participant.getId(), participant).execute();
+            
+            list = studiesApi.getEnrollees(STUDY_ID_1, "all", false, null, null).execute().body();
+            assertFalse(list.getItems().stream().anyMatch(e -> e.getParticipant().getIdentifier().equals(user.getUserId())));
+            
+            list = studiesApi.getEnrollees(STUDY_ID_1, "all", true, null, null).execute().body();
             assertTrue(list.getItems().stream().anyMatch(e -> e.getParticipant().getIdentifier().equals(user.getUserId())));
         } finally {
             user.signOutAndDeleteUser();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyMembershipTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyMembershipTest.java
@@ -9,7 +9,9 @@ import static org.sagebionetworks.bridge.rest.model.Role.RESEARCHER;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.SAGE_ID;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_ID;
 
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -31,6 +33,7 @@ import org.sagebionetworks.bridge.rest.model.IdentifierUpdate;
 import org.sagebionetworks.bridge.rest.model.SignUp;
 import org.sagebionetworks.bridge.rest.model.Study;
 import org.sagebionetworks.bridge.rest.model.StudyParticipant;
+import org.sagebionetworks.bridge.rest.model.UserConsentHistory;
 import org.sagebionetworks.bridge.rest.model.UserSessionInfo;
 import org.sagebionetworks.bridge.rest.model.Withdrawal;
 import org.sagebionetworks.bridge.user.TestUserHelper;
@@ -169,12 +172,13 @@ public class StudyMembershipTest {
         userApi.withdrawFromApp(new Withdrawal().reason("Testing external IDs")).execute();
         
         StudyParticipant withdrawn = appAdminParticipantsApi.getParticipantById(userId, true).execute().body();
+        
         assertEquals(0, withdrawn.getExternalIds().size());
         
         // One enrollment was removed through the legacy approach of set studyIds on a participant update. This actually
         // removes the enrollment, and is being phased out. The second approach called withdrawal and this preserves the 
         // second enrollment object to idB.
-        EnrollmentDetailList list = appAdmin.getClient(StudiesApi.class).getEnrollees(idB, "withdrawn", 0, 10).execute().body();
+        EnrollmentDetailList list = appAdmin.getClient(StudiesApi.class).getEnrollees(idB, "withdrawn", true, 0, 10).execute().body();
         assertEquals(1, list.getItems().size());
         assertEquals(extIdB, list.getItems().get(0).getExternalId());
     }


### PR DESCRIPTION
This should be merged after the main enrollment API PR, then this is only a couple of files.