### PR TITLE
Some cleanup of external id deletion.

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyMembershipTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyMembershipTest.java
@@ -43,7 +43,6 @@ public class StudyMembershipTest {
     private TestUser appAdmin;
     private StudiesApi studiesApi;
     private Set<String> studyIdsToDelete;
-    private Set<String> externalIdsToDelete;
     private Set<TestUser> usersToDelete;
 
     @Before
@@ -54,7 +53,6 @@ public class StudyMembershipTest {
         studiesApi = admin.getClient(StudiesApi.class);
 
         studyIdsToDelete = new HashSet<>();
-        externalIdsToDelete = new HashSet<>();
         usersToDelete = new HashSet<>();
     }
 
@@ -73,17 +71,6 @@ public class StudyMembershipTest {
             } catch(Exception e) {
                 e.printStackTrace();
             }
-        }
-        if (appAdmin != null) {
-            StudiesApi studiesApi = appAdmin.getClient(StudiesApi.class);
-            for (String externalId : externalIdsToDelete) {
-                try {
-                    studiesApi.deleteExternalId(externalId).execute();    
-                } catch(Exception e) {
-                    e.printStackTrace();
-                }
-            }
-            appAdmin.signOutAndDeleteUser();
         }
         for (String studyId : studyIdsToDelete) {
             try {

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadTest.java
@@ -200,7 +200,6 @@ public class UploadTest {
     @AfterClass
     public static void deleteResearcher() throws Exception {
         ForAdminsApi adminsApi = TestUserHelper.getSignedInAdmin().getClient(ForAdminsApi.class);
-        adminsApi.deleteExternalId(EXTERNAL_ID).execute();
         if (researcher != null) {
             researcher.signOutAndDeleteUser();
         }


### PR DESCRIPTION
To delete an external ID, all you need to do is unenroll an account or, as we do in the integration tests, just delete the account it is attached to. 