### PR TITLE
Enrollment deletion APIs and some additional tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.21.16</version>
+            <version>0.21.17</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ActivityEventTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ActivityEventTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.sdk.integration;
 
 import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -133,7 +134,7 @@ public class ActivityEventTest {
     }
 
     @Test
-    public void canCreateAndGetCustomEvent() throws IOException {
+    public void canCrudCustomEvent() throws IOException {
         // Setup
         ActivityEventList activityEventList = usersApi.getActivityEvents().execute().body();
         List<ActivityEvent> activityEvents = activityEventList.getItems();
@@ -143,10 +144,7 @@ public class ActivityEventTest {
         // Create custom event
         DateTime timestamp = DateTime.now(DateTimeZone.UTC);
         usersApi.createCustomActivityEvent(
-                new CustomActivityEventRequest()
-                        .eventKey(EVENT_KEY1)
-                        .timestamp(timestamp))
-                .execute();
+                new CustomActivityEventRequest().eventKey(EVENT_KEY1).timestamp(timestamp)).execute();
 
         // Verify created event
         activityEventList = usersApi.getActivityEvents().execute().body();
@@ -165,6 +163,15 @@ public class ActivityEventTest {
         // Verify researcher's view of created event
         activityEventList = researchersApi.getActivityEventsForParticipant(participant.getId()).execute().body();
         assertEquals(updatedActivityEvents, activityEventList.getItems());
+        
+        // delete the event
+        usersApi.createCustomActivityEvent(
+                new CustomActivityEventRequest().eventKey(EVENT_KEY1)).execute();
+        activityEventList = usersApi.getActivityEvents().execute().body();
+        assertFalse(activityEventList.getItems().stream().map(ActivityEvent::getEventId)
+                .collect(Collectors.toSet()).contains(expectedEventKey));
+        assertFalse(activityEventList.getItems().stream().map(ActivityEvent::getEventId)
+                .collect(Collectors.toSet()).contains(EVENT_KEY1));
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ActivityEventTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ActivityEventTest.java
@@ -144,7 +144,7 @@ public class ActivityEventTest {
         // Create custom event
         DateTime timestamp = DateTime.now(DateTimeZone.UTC);
         usersApi.createCustomActivityEvent(
-                new CustomActivityEventRequest().eventKey(EVENT_KEY1).timestamp(timestamp)).execute();
+                new CustomActivityEventRequest().eventId(EVENT_KEY1).timestamp(timestamp)).execute();
 
         // Verify created event
         activityEventList = usersApi.getActivityEvents().execute().body();
@@ -165,8 +165,7 @@ public class ActivityEventTest {
         assertEquals(updatedActivityEvents, activityEventList.getItems());
         
         // delete the event
-        usersApi.createCustomActivityEvent(
-                new CustomActivityEventRequest().eventKey(EVENT_KEY1)).execute();
+        usersApi.deleteCustomActivityEvent(EVENT_KEY1).execute();
         activityEventList = usersApi.getActivityEvents().execute().body();
         assertFalse(activityEventList.getItems().stream().map(ActivityEvent::getEventId)
                 .collect(Collectors.toSet()).contains(expectedEventKey));
@@ -206,7 +205,7 @@ public class ActivityEventTest {
         DateTime timestamp2 = DateTime.now(DateTimeZone.UTC);
         
         CustomActivityEventRequest request = new CustomActivityEventRequest();
-        request.setEventKey(EVENT_KEY1);
+        request.setEventId(EVENT_KEY1);
         request.setTimestamp(timestamp1);
         
         researchersApi.createActivityEventForParticipant(user.getUserId(), request).execute();
@@ -230,15 +229,15 @@ public class ActivityEventTest {
     @Test
     public void createActivityEventScopedForStudy() throws Exception {
         // Because this is set first, it is immutable and will not be changed by the study-scoped value.
-        // Both with exist side-by-side (TODO: also test replacement scenario).
+        // Both with exist side-by-side
         DateTime globalTimestamp = DateTime.now(UTC).minusDays(2);
         CustomActivityEventRequest globalRequest = new CustomActivityEventRequest()
-                .eventKey(EVENT_KEY1).timestamp(globalTimestamp);
+                .eventId(EVENT_KEY1).timestamp(globalTimestamp);
         researchersApi.createActivityEventForParticipant(user.getUserId(), globalRequest).execute();
         
         DateTime studyScopedTimestamp = DateTime.now(UTC);  
         CustomActivityEventRequest studyScopedRequest = new CustomActivityEventRequest()
-            .eventKey(EVENT_KEY1).timestamp(studyScopedTimestamp);
+            .eventId(EVENT_KEY1).timestamp(studyScopedTimestamp);
         researchersApi.createStudyParticipantActivityEvent(STUDY_ID_1, user.getUserId(), studyScopedRequest).execute();
         
         ActivityEventList globalList = researchersApi.getActivityEventsForParticipant(user.getUserId()).execute().body();
@@ -260,11 +259,11 @@ public class ActivityEventTest {
         
         // Verify that a user can create a custom event, and that it is visible to researchers
         globalTimestamp = globalTimestamp.minusWeeks(2);
-        globalRequest = new CustomActivityEventRequest().eventKey(EVENT_KEY2).timestamp(globalTimestamp);
+        globalRequest = new CustomActivityEventRequest().eventId(EVENT_KEY2).timestamp(globalTimestamp);
         usersApi.createCustomActivityEvent(globalRequest).execute();
         
         studyScopedTimestamp = studyScopedTimestamp.minusWeeks(2);
-        studyScopedRequest = new CustomActivityEventRequest().eventKey(EVENT_KEY2).timestamp(studyScopedTimestamp);
+        studyScopedRequest = new CustomActivityEventRequest().eventId(EVENT_KEY2).timestamp(studyScopedTimestamp);
         usersApi.createActivityEventForSelf(STUDY_ID_1, studyScopedRequest).execute();
 
         // user can see these events
@@ -290,7 +289,7 @@ public class ActivityEventTest {
     public void globalEventsDoNotCreateStudyVersions() throws Exception {
         DateTime globalTimestamp = DateTime.now(UTC).minusDays(2);
         CustomActivityEventRequest globalRequest = new CustomActivityEventRequest()
-                .eventKey(EVENT_KEY1).timestamp(globalTimestamp);
+                .eventId(EVENT_KEY1).timestamp(globalTimestamp);
         researchersApi.createActivityEventForParticipant(user.getUserId(), globalRequest).execute();
 
         ActivityEventList scopedList = researchersApi.getStudyParticipantActivityEvents(STUDY_ID_1, user.getUserId()).execute().body();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/EnrollmentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/EnrollmentTest.java
@@ -12,7 +12,6 @@ import static org.sagebionetworks.bridge.sdk.integration.Tests.STUDY_ID_1;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 
 import org.joda.time.DateTime;
 import org.junit.After;
@@ -27,7 +26,6 @@ import org.sagebionetworks.bridge.rest.api.StudiesApi;
 import org.sagebionetworks.bridge.rest.model.Enrollment;
 import org.sagebionetworks.bridge.rest.model.EnrollmentDetailList;
 import org.sagebionetworks.bridge.rest.model.IdentifierHolder;
-import org.sagebionetworks.bridge.rest.model.Role;
 import org.sagebionetworks.bridge.rest.model.SignUp;
 import org.sagebionetworks.bridge.rest.model.StudyParticipant;
 import org.sagebionetworks.bridge.user.TestUserHelper;

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ForStudyCoordinatorsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ForStudyCoordinatorsTest.java
@@ -142,8 +142,8 @@ public class ForStudyCoordinatorsTest {
         
         // Just verify these all work, though there's no data
         ActivityEventList aeList = coordApi.getStudyParticipantActivityEvents(STUDY_ID_1, userId).execute().body();
-        assertEquals(ImmutableSet.of("study_start_date", "created_on"), 
-                aeList.getItems().stream().map(ActivityEvent::getEventId).collect(toSet()));
+        assertTrue(aeList.getItems().stream().map(ActivityEvent::getEventId)
+                .collect(toSet()).containsAll(ImmutableSet.of("study_start_date", "created_on")));
         
         NotificationRegistrationList nrList = coordApi.getStudyParticipantNotificationRegistrations(STUDY_ID_1, userId).execute().body();
         assertTrue(nrList.getItems().isEmpty());

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduledActivityRecurringTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduledActivityRecurringTest.java
@@ -121,7 +121,7 @@ public class ScheduledActivityRecurringTest {
         
         // Create an event two days in the past to schedule against
         usersApi.createCustomActivityEvent(
-                new CustomActivityEventRequest().eventKey(CUSTOM_EVENT).timestamp(now.minusDays(2))).execute();
+                new CustomActivityEventRequest().eventId(CUSTOM_EVENT).timestamp(now.minusDays(2))).execute();
 
         // Gilbert Islands, +12:00 hours.
         String mtz1 = now.withZone(MTZ).toLocalDate().toString()+M_TIME_OF_DAY;
@@ -155,7 +155,6 @@ public class ScheduledActivityRecurringTest {
         assertEquals(ytz4, activities.getItems().get(3).getScheduledOn().toString());
         
         // Return to +12:00 land and ask for activites for three days, but one day in the future
-        // TODO
         ScheduledActivityListV4 activitiesV4 = filterList(usersApi
                 .getScheduledActivitiesByDateRange(now.plusDays(1).withZone(MTZ), now.plusDays(3).plusMinutes(1).withZone(MTZ))
                 .execute().body(), schedulePlan.getGuid());


### PR DESCRIPTION
Verifies you can delete a custom event; verifies on server pathway that looked like it might be trouble (it isn't); made one test more resilient to other auto-custom events in the api app's config.