### PR TITLE
Fix integ tests for AWS Migration

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/HttpTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/HttpTest.java
@@ -11,6 +11,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.rest.model.Environment;
@@ -65,6 +66,8 @@ public class HttpTest {
         assertEquals(200, response.getStatusLine().getStatusCode());
     }
 
+    // HTTPS Redirect is temporarily disabled for dev and staging for the AWS Migration.
+    @Ignore
     @Test
     public void testHttpRedirect() throws Exception {
         // This test only makes sense on servers supporting https redirection, and that's not

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/IntentToParticipateTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/IntentToParticipateTest.java
@@ -13,9 +13,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.sagebionetworks.bridge.rest.ApiClientProvider;
-import org.sagebionetworks.bridge.rest.ClientManager;
-import org.sagebionetworks.bridge.rest.Config;
-import org.sagebionetworks.bridge.rest.RestUtils;
 import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
 import org.sagebionetworks.bridge.rest.api.ForSuperadminsApi;
 import org.sagebionetworks.bridge.rest.api.IntentToParticipateApi;
@@ -73,13 +70,8 @@ public class IntentToParticipateTest {
                     .subpopGuid(TEST_APP_ID)
                     .osName("iPhone")
                     .consentSignature(sig);
-            
-            Config config = new Config();
-            String baseUrl = ClientManager.getUrl(config.getEnvironment());
-            String clientInfo = RestUtils.getUserAgent(admin.getClientManager().getClientInfo());
-            String lang = RestUtils.getAcceptLanguage(admin.getClientManager().getAcceptedLanguages());
-            
-            ApiClientProvider provider = new ApiClientProvider(baseUrl, clientInfo, lang, TEST_APP_ID);
+
+            ApiClientProvider provider = Tests.getUnauthenticatedClientProvider(admin.getClientManager(), TEST_APP_ID);
             
             IntentToParticipateApi intentApi = provider.getClient(IntentToParticipateApi.class);
             intentApi.submitIntentToParticipate(intent).execute();
@@ -144,13 +136,8 @@ public class IntentToParticipateTest {
                     .subpopGuid(TEST_APP_ID)
                     .osName("iPhone")
                     .consentSignature(sig);
-            
-            Config config = new Config();
-            String baseUrl = ClientManager.getUrl(config.getEnvironment());
-            String clientInfo = RestUtils.getUserAgent(admin.getClientManager().getClientInfo());
-            String lang = RestUtils.getAcceptLanguage(admin.getClientManager().getAcceptedLanguages());
-            
-            ApiClientProvider provider = new ApiClientProvider(baseUrl, clientInfo, lang, TEST_APP_ID);
+
+            ApiClientProvider provider = Tests.getUnauthenticatedClientProvider(admin.getClientManager(), TEST_APP_ID);
             
             IntentToParticipateApi intentApi = provider.getClient(IntentToParticipateApi.class);
             intentApi.submitIntentToParticipate(intent).execute();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SharedModuleMetadataTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SharedModuleMetadataTest.java
@@ -84,7 +84,8 @@ public class SharedModuleMetadataTest {
         apiDeveloperModulesApi = apiDeveloper.getClient(SharedModulesApi.class);
         sharedDeveloper = TestUserHelper.createAndSignInUser(SharedModuleMetadataTest.class, SHARED_APP_ID, DEVELOPER);
         sharedDeveloperModulesApi = sharedDeveloper.getClient(SharedModulesApi.class);
-        nonAuthSharedModulesApi = TestUserHelper.getNonAuthClient(SharedModulesApi.class, TEST_APP_ID);
+        nonAuthSharedModulesApi = Tests.getUnauthenticatedClientProvider(admin.getClientManager(), TEST_APP_ID)
+                .getClient(SharedModulesApi.class);
         devUploadSchemasApi = sharedDeveloper.getClient(UploadSchemasApi.class);
         devSurveysApi = sharedDeveloper.getClient(SurveysApi.class);
         adminsApi = admin.getClient(ForAdminsApi.class);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
@@ -23,6 +23,9 @@ import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.sagebionetworks.bridge.rest.ApiClientProvider;
+import org.sagebionetworks.bridge.rest.ClientManager;
+import org.sagebionetworks.bridge.rest.RestUtils;
 import org.sagebionetworks.bridge.rest.model.ABTestGroup;
 import org.sagebionetworks.bridge.rest.model.ABTestScheduleStrategy;
 import org.sagebionetworks.bridge.rest.model.Activity;
@@ -67,6 +70,15 @@ public class Tests {
     public static ClientInfo getClientInfoWithVersion(String osName, int version) {
         return new ClientInfo().appName(APP_NAME).appVersion(version).deviceName(APP_NAME).osName(osName)
                 .osVersion("2.0.0").sdkName("BridgeJavaSDK").sdkVersion(Integer.parseInt(IntegTestUtils.CONFIG.getSdkVersion()));
+    }
+
+    // This API exists because there's a bug in TestUserHelper.getNonAuthClient() which uses ClientManager.getUrl()
+    // instead of ClientManager.getHostUrl().
+    public static ApiClientProvider getUnauthenticatedClientProvider(ClientManager clientManager, String appId) {
+        String baseUrl = clientManager.getHostUrl();
+        String clientInfo = RestUtils.getUserAgent(clientManager.getClientInfo());
+        String lang = RestUtils.getAcceptLanguage(clientManager.getAcceptedLanguages());
+        return new ApiClientProvider(baseUrl, clientInfo, lang, appId);
     }
 
     public static String randomIdentifier(Class<?> cls) {


### PR DESCRIPTION
See also https://sagebionetworks.jira.com/browse/BRIDGE-1931

Fixes for integration tests to support AWS Migration
* Https redirect test temporarily disabled, since that's not available in our Dev AWS account yet.
* A few tests used ClientManager.getUrl() instead of ClientManager.getHostUrl(). This prevents overriding the host, which meant some API calls were calling into our Prod AWS stacks instead of our Dev AWS stacks.

See also
https://github.com/Sage-Bionetworks/BridgeServer2-infra/pull/44
https://github.com/Sage-Bionetworks/BridgeServer2/pull/338