### PR TITLE
Pretty sure this is the reason ParticipantDataTest leaves behind an account each run.

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantDataTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantDataTest.java
@@ -155,7 +155,6 @@ public class ParticipantDataTest {
 
     @Test
     public void correctExceptionsOnBadRequest() throws Exception {
-        user = TestUserHelper.createAndSignInUser(ParticipantDataTest.class, true);
         ForConsentedUsersApi usersApi = user.getClient(ForConsentedUsersApi.class);
         try {
             usersApi.getAllDataForSelf(OFFSET_KEY, 4).execute();


### PR DESCRIPTION
It orphans the first reference to the user that holds the account that is never deleted.