### PR TITLE
Updating to specify disposition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.22.10</version>
+            <version>0.22.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AppConfigTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AppConfigTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.sagebionetworks.bridge.rest.model.FileDisposition.INLINE;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.ORG_ID_1;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.randomIdentifier;
 
@@ -193,6 +194,7 @@ public class AppConfigTest {
         
         FileMetadata meta = new FileMetadata();
         meta.setName("test file");
+        meta.setDisposition(INLINE);
         fileKeys = filesApi.createFile(meta).execute().body();
         
         File file = new File("src/test/resources/file-test/test.pdf");

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/FileTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/FileTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.sagebionetworks.bridge.rest.model.FileDisposition.INLINE;
 import static org.sagebionetworks.bridge.rest.model.FileRevisionStatus.AVAILABLE;
 import static org.sagebionetworks.bridge.rest.model.FileRevisionStatus.PENDING;
 import static org.sagebionetworks.bridge.rest.model.Role.DEVELOPER;
@@ -60,6 +61,7 @@ public class FileTest {
         metadata.setName("TestFile Name");
         metadata.setDescription("TestFile Description");
         metadata.setDeleted(true);
+        metadata.setDisposition(INLINE);
         
         ForDevelopersApi devsApi = developer.getClient(ForDevelopersApi.class);
         
@@ -135,6 +137,7 @@ public class FileTest {
             metadata.setName("TestFile Name");
             metadata.setDescription("TestFile Description");
             metadata.setDeleted(true);
+            metadata.setDisposition(INLINE);
             
             ForDevelopersApi devsApi = developer.getClient(ForDevelopersApi.class);
             

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyTest.java
@@ -50,7 +50,6 @@ import org.sagebionetworks.bridge.rest.model.SignInType;
 import org.sagebionetworks.bridge.rest.model.SignUp;
 import org.sagebionetworks.bridge.rest.model.Study;
 import org.sagebionetworks.bridge.rest.model.StudyList;
-import org.sagebionetworks.bridge.rest.model.StudyPhase;
 import org.sagebionetworks.bridge.rest.model.VersionHolder;
 import org.sagebionetworks.bridge.user.TestUserHelper;
 import org.sagebionetworks.bridge.user.TestUserHelper.TestUser;
@@ -99,14 +98,6 @@ public class StudyTest {
         }
     }
 
-    @Test
-    public void existingStudiesAreLegacy() throws Exception {
-        StudiesApi studiesApi = admin.getClient(StudiesApi.class);
-
-        Study study = studiesApi.getStudy(STUDY_ID_1).execute().body();
-        assertEquals(StudyPhase.LEGACY, study.getPhase());
-    }
-    
     @SuppressWarnings("unchecked")
     @Test
     public void test() throws IOException {


### PR DESCRIPTION
I also had to rebuild my environment in the process of testing the study logo uploads, and found one integration test that fails in this scenario, because the re-created study is no longer a legacy study. This is fine, that migration is done and going forward, the default is design.