### PR TITLE
Updating based on small API changes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.22.20</version>
+            <version>0.22.21</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AdherenceRecordsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AdherenceRecordsTest.java
@@ -181,9 +181,6 @@ public class AdherenceRecordsTest {
     
     @After
     public void after() throws Exception {
-        study1.setScheduleGuid(null);
-        developersApi.updateStudy(study1.getIdentifier(), study1).execute().body();
-        
         TestUser admin = TestUserHelper.getSignedInAdmin();
         AssessmentsApi assessmentsApi = admin.getClient(AssessmentsApi.class);
         SchedulesV2Api schedulesApi = admin.getClient(SchedulesV2Api.class);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/Schedule2Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/Schedule2Test.java
@@ -52,7 +52,6 @@ import org.sagebionetworks.bridge.rest.model.SessionInfo;
 import org.sagebionetworks.bridge.rest.model.Study;
 import org.sagebionetworks.bridge.rest.model.TimeWindow;
 import org.sagebionetworks.bridge.rest.model.Timeline;
-import org.sagebionetworks.bridge.rest.model.VersionHolder;
 import org.sagebionetworks.bridge.user.TestUserHelper;
 import org.sagebionetworks.bridge.user.TestUserHelper.TestUser;
 
@@ -97,16 +96,7 @@ public class Schedule2Test {
     public void after() throws Exception {
         TestUser admin = TestUserHelper.getSignedInAdmin();
         SchedulesV2Api adminSchedulesApi = admin.getClient(SchedulesV2Api.class);
-        StudiesApi studiesApi = admin.getClient(StudiesApi.class);
         
-        Study study = studiesApi.getStudy(STUDY_ID_1).execute().body();
-        if (study.getScheduleGuid() != null) {
-            study.setScheduleGuid(null);
-            studiesApi.updateStudy(STUDY_ID_1, study).execute().body();
-        }
-        if (schedule != null && schedule.getGuid() != null) {
-            adminSchedulesApi.deleteSchedule(schedule.getGuid()).execute();
-        }
         if (org1ScheduleGuid != null) {
             adminSchedulesApi.deleteSchedule(org1ScheduleGuid).execute();
         }
@@ -386,10 +376,6 @@ public class Schedule2Test {
         
         // Add it to study 1
         Study study = studiesApi.getStudy(STUDY_ID_1).execute().body();
-        study.setScheduleGuid(schedule.getGuid());
-        VersionHolder versionHolder = studiesApi.updateStudy(STUDY_ID_1, study).execute().body();
-        study.setVersion(versionHolder.getVersion());
-        
         user = TestUserHelper.createAndSignInUser(Schedule2Test.class, true);
 
         // This user should now have a timeline via study1:
@@ -414,8 +400,8 @@ public class Schedule2Test {
         assertEquals(200, res.code());
         assertNotNull(res.body());
         
-        study.setScheduleGuid(null);
-        studiesApi.updateStudy(STUDY_ID_1, study).execute().body();
+        TestUser admin = TestUserHelper.getSignedInAdmin();
+        admin.getClient(SchedulesV2Api.class).deleteSchedule(study.getScheduleGuid()).execute();
         
         // and this is just a flat-out error
         try {


### PR DESCRIPTION
Because schedules are now deleted when their encompassing study can change, and scheduleGuid is now read-only in the study, instead of making that association, you just associate the schedule to the study as a side effect of the API you're calling.