### PR TITLE
Adding clientTimeZone to participant account crud tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.22.21</version>
+            <version>0.22.22</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AccountsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AccountsTest.java
@@ -106,7 +106,8 @@ public class AccountsTest {
                 .clientData("Test")
                 .languages(ImmutableList.of("en", "fr"))
                 .password(PASSWORD)
-                .note("test note 1");
+                .note("test note 1")
+                .clientTimeZone("America/Los_Angeles");
         
         emailUserId = orgAdminApi.createAccount(account).execute().body().getIdentifier();
         
@@ -125,6 +126,7 @@ public class AccountsTest {
         assertEquals(ImmutableList.of("en", "fr"), retrieved.getLanguages());
         assertEquals(orgId, retrieved.getOrgMembership());
         assertEquals("test note 1", retrieved.getNote());
+        assertEquals("America/Los_Angeles", retrieved.getClientTimeZone());
         assertNull(retrieved.getPassword());
         
         AccountSummarySearch search = new AccountSummarySearch().emailFilter(email);
@@ -134,11 +136,13 @@ public class AccountsTest {
         // update the account
         retrieved.setFirstName("Alternate first name");
         retrieved.setNote("test note 2");
+        retrieved.setClientTimeZone("Africa/Sao_Tome");
         orgAdminApi.updateAccount(emailUserId, retrieved).execute();
         
         Account retrieved2 = orgAdminApi.getAccount(emailUserId).execute().body();
         assertEquals("Alternate first name", retrieved2.getFirstName());
         assertEquals("test note 2", retrieved2.getNote());
+        assertEquals("Africa/Sao_Tome", retrieved2.getClientTimeZone());
         
         // request info. There's not a lot in it since the user cannot sign in (not verified).
         RequestInfo info = orgAdminApi.getAccountRequestInfo(emailUserId).execute().body();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
@@ -320,6 +320,7 @@ public class ParticipantsTest {
         participant.setStatus(DISABLED); // should be ignored
         participant.setAttributes(attributes);
         participant.setNote("test note 1");
+        participant.setClientTimeZone("America/Los_Angeles");
         
         ParticipantsApi participantsApi = researcher.getClient(ParticipantsApi.class);
         IdentifierHolder idHolder = participantsApi.createParticipant(participant).execute().body();
@@ -363,6 +364,7 @@ public class ParticipantsTest {
             assertFalse(retrieved.isPhoneVerified());
             createdOn = retrieved.getCreatedOn();
             assertEquals("test note 1", retrieved.getNote());
+            assertEquals("America/Los_Angeles", retrieved.getClientTimeZone());
 
             // Can also get by the Synapse ID
             retrieved = participantsApi.getParticipantById(retrieved.getId(), true).execute().body();
@@ -389,6 +391,7 @@ public class ParticipantsTest {
             Phone newPhone = new Phone().number("4152588569").regionCode("CA");
             newParticipant.setPhone(newPhone);
             newParticipant.setNote("note2");
+            newParticipant.setClientTimeZone("Africa/Sao_Tome");
             // cannot set Synapse User ID or the account will be enabled.
             
             participantsApi.updateParticipant(id, newParticipant).execute();
@@ -417,6 +420,7 @@ public class ParticipantsTest {
             assertEquals(UNVERIFIED, retrieved.getStatus()); // researchers cannot enable users
             assertEquals(createdOn, retrieved.getCreatedOn()); // hasn't been changed, still exists
             assertEquals("note2", retrieved.getNote());
+            assertEquals("Africa/Sao_Tome", retrieved.getClientTimeZone());
         } finally {
             if (id != null) {
                 admin.getClient(ForAdminsApi.class).deleteUser(id).execute();


### PR DESCRIPTION
For [BRIDGE-3047](https://sagebionetworks.jira.com/browse/BRIDGE-3047).

Adding clientTimeZone field to StudyParticipant as a reference for the participant's local time zone.