### PR TITLE
Test changes for developer access to test accounts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>BridgeIntegTestUtils</artifactId>
-            <version>1.2.4</version>
+            <version>1.2.5</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AccountsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AccountsTest.java
@@ -296,7 +296,7 @@ public class AccountsTest {
         StudyParticipantsApi coordParticipantApi = studyCoordinator.getClient(StudyParticipantsApi.class);
         IdentifierHolder idHolder = coordParticipantApi.createStudyParticipant(STUDY_ID_1, signUp).execute().body();
         
-        coordParticipantApi.deleteTestStudyParticipant(STUDY_ID_1, idHolder.getIdentifier()).execute();
+        coordParticipantApi.deleteStudyParticipant(STUDY_ID_1, idHolder.getIdentifier()).execute();
         
         try {
             coordParticipantApi.getStudyParticipantById(STUDY_ID_1, idHolder.getIdentifier(), false).execute();    
@@ -323,7 +323,7 @@ public class AccountsTest {
             
         }
         try {
-            coordParticipantApi.deleteTestStudyParticipant(STUDY_ID_1, idHolder.getIdentifier()).execute();
+            coordParticipantApi.deleteStudyParticipant(STUDY_ID_1, idHolder.getIdentifier()).execute();
             fail("Should have thrown exception");
         } catch(UnauthorizedException e) {
             assertEquals("Account is not a test account or it is already in use.", e.getMessage());

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthorizationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthorizationTest.java
@@ -1,0 +1,232 @@
+package org.sagebionetworks.bridge.sdk.integration;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.sagebionetworks.bridge.rest.model.Role.DEVELOPER;
+import static org.sagebionetworks.bridge.rest.model.Role.RESEARCHER;
+import static org.sagebionetworks.bridge.rest.model.Role.STUDY_COORDINATOR;
+import static org.sagebionetworks.bridge.rest.model.Role.STUDY_DESIGNER;
+import static org.sagebionetworks.bridge.sdk.integration.Tests.STUDY_ID_1;
+import static org.sagebionetworks.bridge.util.IntegTestUtils.SAGE_ID;
+
+import java.util.concurrent.Callable;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.sagebionetworks.bridge.rest.api.ForOrgAdminsApi;
+import org.sagebionetworks.bridge.rest.api.ParticipantsApi;
+import org.sagebionetworks.bridge.rest.api.StudiesApi;
+import org.sagebionetworks.bridge.rest.api.StudyParticipantsApi;
+import org.sagebionetworks.bridge.rest.model.AccountSummaryList;
+import org.sagebionetworks.bridge.rest.model.AccountSummarySearch;
+import org.sagebionetworks.bridge.rest.model.Enrollment;
+import org.sagebionetworks.bridge.rest.model.StudyParticipant;
+import org.sagebionetworks.bridge.user.TestUserHelper;
+import org.sagebionetworks.bridge.user.TestUserHelper.TestUser;
+
+import retrofit2.Call;
+import retrofit2.Response;
+
+public class AuthorizationTest {
+
+    private static TestUser developer;
+    private static TestUser researcher;
+    private static TestUser studyDesigner;
+    private static TestUser studyCoordinator;
+    
+    private TestUser prodUser;
+    private TestUser testUser;
+    
+    private String prodUserId;
+    private String prodUserEmail;
+    private String testUserId;
+    private String testUserEmail;
+
+    @BeforeClass
+    public static void beforeTests() throws Exception {
+        developer = TestUserHelper.createAndSignInUser(AuthorizationTest.class, false, DEVELOPER);
+        researcher = TestUserHelper.createAndSignInUser(AuthorizationTest.class, false, RESEARCHER);
+        studyDesigner = TestUserHelper.createAndSignInUser(AuthorizationTest.class, false, STUDY_DESIGNER);
+        studyCoordinator = TestUserHelper.createAndSignInUser(AuthorizationTest.class, false, STUDY_COORDINATOR);
+
+        // remove the app-scoped accounts from an organization (at first) to verify they work
+        // without organizational associations
+        TestUser admin = TestUserHelper.getSignedInAdmin();
+        ForOrgAdminsApi orgApi = admin.getClient(ForOrgAdminsApi.class);
+        orgApi.removeMember(SAGE_ID, developer.getUserId()).execute();
+        orgApi.removeMember(SAGE_ID, researcher.getUserId()).execute();
+    }
+    
+    @Before
+    public void before() throws Exception {
+        prodUser = TestUserHelper.createAndSignInUser(AuthorizationTest.class, false);
+        testUser = new TestUserHelper.Builder(AuthorizationTest.class).withTestDataGroup().createAndSignInUser();
+        prodUserId = prodUser.getUserId();
+        prodUserEmail = prodUser.getEmail();
+        testUserId = testUser.getUserId();
+        testUserEmail = testUser.getEmail();
+    }
+    
+    @AfterClass
+    public static void afterTests() throws Exception {
+        if (developer != null) {
+            developer.signOutAndDeleteUser();    
+        }
+        if (researcher != null) {
+            researcher.signOutAndDeleteUser();    
+        }
+        if (studyDesigner != null) {
+            studyDesigner.signOutAndDeleteUser();            
+        }
+        if (studyCoordinator != null) {
+            studyCoordinator.signOutAndDeleteUser();    
+        }
+    }
+    
+    @After
+    public void after( ) throws Exception {
+        if (prodUser != null) {
+            prodUser.signOutAndDeleteUser();    
+        }
+        if (testUser != null) {
+            testUser.signOutAndDeleteUser();
+        }
+    }
+    
+    @Test
+    public void getById() throws Exception {
+        ParticipantsApi devPartApi = developer.getClient(ParticipantsApi.class);
+        ParticipantsApi resPartApi = researcher.getClient(ParticipantsApi.class);
+        StudyParticipantsApi desPartApi = studyDesigner.getClient(StudyParticipantsApi.class);
+        StudyParticipantsApi coordPartApi = studyCoordinator.getClient(StudyParticipantsApi.class);
+        TestUser admin = TestUserHelper.getSignedInAdmin();
+        ForOrgAdminsApi orgApi = admin.getClient(ForOrgAdminsApi.class);
+        StudiesApi coordStudiesApi = studyCoordinator.getClient(StudiesApi.class);
+
+        // Developer can access test user, but not a production user
+        shouldFail(() -> devPartApi.getParticipantById(prodUserId, false));
+        devPartApi.getParticipantById(testUserId, false).execute();
+        
+        // Researchers can access both users
+        resPartApi.getParticipantById(prodUserId, false).execute();
+        resPartApi.getParticipantById(testUserId, false).execute();
+        
+        // Designers cannot access either of these users because they are not in a study
+        shouldFail(() -> desPartApi.getStudyParticipantById(STUDY_ID_1, prodUserId, false));
+        shouldFail(() -> desPartApi.getStudyParticipantById(STUDY_ID_1, testUserId, false));
+        
+        // Coordinators also cannot access these users because they are not in a study
+        shouldFail(() -> coordPartApi.getStudyParticipantById(STUDY_ID_1, prodUserId, false));
+        shouldFail(() -> coordPartApi.getStudyParticipantById(STUDY_ID_1, testUserId, false));
+        
+        // PUT STUDY-SCOPED ADMINS INTO ORG
+        orgApi.addMember(SAGE_ID, developer.getUserId()).execute();
+        orgApi.addMember(SAGE_ID, researcher.getUserId()).execute();
+        
+        // these don't change
+        shouldFail(() -> devPartApi.getParticipantById(prodUserId, false));
+        devPartApi.getParticipantById(testUserId, false).execute();
+        resPartApi.getParticipantById(prodUserId, false).execute();
+        resPartApi.getParticipantById(testUserId, false).execute();
+        
+        // ENROLL USERS IN STUDY 1
+        coordStudiesApi.enrollParticipant(STUDY_ID_1, new Enrollment().userId(prodUserId)).execute();
+        coordStudiesApi.enrollParticipant(STUDY_ID_1, new Enrollment().userId(testUserId)).execute();
+        
+        // developer is the same
+        shouldFail(() -> devPartApi.getParticipantById(prodUserId, false));
+        devPartApi.getParticipantById(testUserId, false).execute();
+
+        // researcher is the same
+        resPartApi.getParticipantById(prodUserId, false).execute();
+        resPartApi.getParticipantById(testUserId, false).execute();
+        
+        // designer can see the test account now that it is enrolled in accessible study
+        shouldFail(() -> desPartApi.getStudyParticipantById(STUDY_ID_1, prodUserId, false));
+        desPartApi.getStudyParticipantById(STUDY_ID_1, testUserId, false).execute();
+        
+        // coordinator can see both now that they are enrolled in an accessible study
+        coordPartApi.getStudyParticipantById(STUDY_ID_1, prodUserId, false).execute();
+        coordPartApi.getStudyParticipantById(STUDY_ID_1, testUserId, false).execute();
+    }
+    
+    @Test
+    public void getAccountSummaries() throws Exception {
+        // Note that in these tests, we do not have to explicitly set the test_user flag in search.
+        ParticipantsApi devPartApi = developer.getClient(ParticipantsApi.class);
+        ParticipantsApi resPartApi = researcher.getClient(ParticipantsApi.class);
+        StudyParticipantsApi desPartApi = studyDesigner.getClient(StudyParticipantsApi.class);
+        StudyParticipantsApi coordPartApi = studyCoordinator.getClient(StudyParticipantsApi.class);
+        StudiesApi coordStudiesApi = studyCoordinator.getClient(StudiesApi.class);
+
+        // Developer can access test user, but not a production user
+        shouldInclude(() -> devPartApi.searchAccountSummaries(search(testUserEmail)) );
+        shouldExclude(() -> devPartApi.searchAccountSummaries(search(prodUserEmail)) );
+
+        // Researcher can access both, but not a production user
+        shouldInclude(() -> resPartApi.searchAccountSummaries(search(testUserEmail)) );
+        shouldInclude(() -> resPartApi.searchAccountSummaries(search(prodUserEmail)) );
+        
+        // Designers cannot access either of these users because they are not in a study
+        shouldExclude(() -> desPartApi.getStudyParticipants(STUDY_ID_1, search(prodUserEmail)));
+        shouldExclude(() -> desPartApi.getStudyParticipants(STUDY_ID_1, search(testUserEmail)));
+        
+        // Coordinators also cannot access these users because they are not in a study
+        shouldExclude(() -> desPartApi.getStudyParticipants(STUDY_ID_1, search(prodUserEmail)));
+        shouldExclude(() -> desPartApi.getStudyParticipants(STUDY_ID_1, search(testUserEmail)));
+
+        // ENROLL USERS IN STUDY 1
+        coordStudiesApi.enrollParticipant(STUDY_ID_1, new Enrollment().userId(prodUserId)).execute();
+        coordStudiesApi.enrollParticipant(STUDY_ID_1, new Enrollment().userId(testUserId)).execute();
+        
+        // Developer is the same
+        shouldInclude(() -> devPartApi.searchAccountSummaries(search(testUserEmail)) );
+        shouldExclude(() -> devPartApi.searchAccountSummaries(search(prodUserEmail)) );
+
+        // Researcher is the same
+        shouldInclude(() -> resPartApi.searchAccountSummaries(search(testUserEmail)) );
+        shouldInclude(() -> resPartApi.searchAccountSummaries(search(prodUserEmail)) );
+
+        // Study designers can now access test users
+        shouldExclude(() -> desPartApi.getStudyParticipants(STUDY_ID_1, search(prodUserEmail)));
+        shouldInclude(() -> desPartApi.getStudyParticipants(STUDY_ID_1, search(testUserEmail)));
+        
+        // Study coordinators can now access all study users
+        shouldInclude(() -> coordPartApi.getStudyParticipants(STUDY_ID_1, search(prodUserEmail)));
+        shouldInclude(() -> coordPartApi.getStudyParticipants(STUDY_ID_1, search(testUserEmail)));
+    }
+    
+    private void shouldFail(Callable<Call<StudyParticipant>> callable) {
+        try {
+            callable.call().execute();
+            fail("Should have thrown exception");
+        } catch(Exception e) {
+        }
+    }
+    
+    private void shouldInclude(Callable<Call<AccountSummaryList>> callable) {
+        try {
+            AccountSummaryList list = callable.call().execute().body();
+            assertFalse(list.getItems().isEmpty());
+        } catch(Exception e) {
+            fail("Threw exception");
+        }
+    }
+    
+    private void shouldExclude(Callable<Call<AccountSummaryList>> callable) {
+        try {
+            AccountSummaryList list = callable.call().execute().body();
+            assertTrue(list.getItems().isEmpty());
+        } catch(Exception e) {
+            fail("Threw exception");
+        }
+    }
+    
+    private AccountSummarySearch search(String email) {
+        return new AccountSummarySearch().emailFilter(email);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthorizationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthorizationTest.java
@@ -216,8 +216,8 @@ public class AuthorizationTest {
         devPartApi.updateParticipant(testUserId, testParticipant).execute();
 
         // Researchers can update both kinds of accounts
-        resPartApi.updateParticipant(prodUserId, prodParticipant);
-        resPartApi.updateParticipant(testUserId, testParticipant);
+        resPartApi.updateParticipant(prodUserId, prodParticipant).execute();
+        resPartApi.updateParticipant(testUserId, testParticipant).execute();
         
         // As other tests, study coordinators and designers can't do anything with these
         // accounts because they are not in an accessible study
@@ -234,8 +234,8 @@ public class AuthorizationTest {
         // Devs and researchers don't change
         shouldFail(() -> devPartApi.updateParticipant(prodUserId, prodParticipant));
         devPartApi.updateParticipant(testUserId, testParticipant).execute();
-        resPartApi.updateParticipant(prodUserId, prodParticipant);
-        resPartApi.updateParticipant(testUserId, testParticipant);
+        resPartApi.updateParticipant(prodUserId, prodParticipant).execute();
+        resPartApi.updateParticipant(testUserId, testParticipant).execute();
         
         // Study designers can work with test accounts
         shouldFail(() -> desPartApi.updateStudyParticipant(STUDY_ID_1, prodUserId, prodParticipant));

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthorizationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthorizationTest.java
@@ -21,6 +21,7 @@ import org.sagebionetworks.bridge.rest.api.ForOrgAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ParticipantsApi;
 import org.sagebionetworks.bridge.rest.api.StudiesApi;
 import org.sagebionetworks.bridge.rest.api.StudyParticipantsApi;
+import org.sagebionetworks.bridge.rest.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.rest.model.AccountSummaryList;
 import org.sagebionetworks.bridge.rest.model.AccountSummarySearch;
 import org.sagebionetworks.bridge.rest.model.Enrollment;
@@ -44,9 +45,6 @@ public class AuthorizationTest {
     private String prodUserEmail;
     private String testUserId;
     private String testUserEmail;
-    
-    private StudyParticipant testParticipant;
-    private StudyParticipant prodParticipant;
 
     @BeforeClass
     public static void beforeTests() throws Exception {
@@ -248,17 +246,11 @@ public class AuthorizationTest {
         coordPartApi.updateStudyParticipant(STUDY_ID_1, testUserId, testParticipant).execute();
     }
     
-//    private void updateStudyParticipantRecords() {
-//        ParticipantsApi resPartApi = researcher.getClient(ParticipantsApi.class);
-//        testParticipant = resPartApi.getParticipantById(testUserId, false).execute().body();
-//        prodParticipant = resPartApi.getParticipantById(prodUserId, false).execute().body();
-//    }
-    
-    private void shouldFail(Callable<Call<?>> callable) {
+    private void shouldFail(Callable<Call<?>> callable) throws Exception {
         try {
             callable.call().execute();
             fail("Should have thrown exception");
-        } catch(Exception e) {
+        } catch(EntityNotFoundException e) {
         }
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ForStudyCoordinatorsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ForStudyCoordinatorsTest.java
@@ -77,7 +77,7 @@ public class ForStudyCoordinatorsTest {
     @After
     public void afterMethod() throws Exception {
         if (id != null) {
-            coordApi.deleteTestStudyParticipant(STUDY_ID_1, id.getIdentifier()).execute();
+            coordApi.deleteStudyParticipant(STUDY_ID_1, id.getIdentifier()).execute();
         }
         if (user != null) {
             user.signOutAndDeleteUser();
@@ -186,7 +186,7 @@ public class ForStudyCoordinatorsTest {
         assertEquals("New First Name", participant.getFirstName());
         assertEquals("New Last Name", participant.getLastName());
         
-        coordApi.deleteTestStudyParticipant(STUDY_ID_1, userId).execute();
+        coordApi.deleteStudyParticipant(STUDY_ID_1, userId).execute();
         id = null;
         
         try {
@@ -270,7 +270,7 @@ public class ForStudyCoordinatorsTest {
         
         // User is not a test user so this fails
         try {
-            coordApi.deleteTestStudyParticipant(STUDY_ID_1, user.getUserId()).execute();
+            coordApi.deleteStudyParticipant(STUDY_ID_1, user.getUserId()).execute();
             fail("Should have thrown an exception");
         } catch(UnauthorizedException e) {
         }
@@ -280,7 +280,7 @@ public class ForStudyCoordinatorsTest {
         coordApi.updateStudyParticipant(STUDY_ID_1, user.getUserId(), participant).execute();
         
         // this now succeeds
-        coordApi.deleteTestStudyParticipant(STUDY_ID_1, user.getUserId()).execute();
+        coordApi.deleteStudyParticipant(STUDY_ID_1, user.getUserId()).execute();
         
         try {
             coordApi.getStudyParticipantById(STUDY_ID_1, user.getUserId(), false).execute();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/HealthDataTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/HealthDataTest.java
@@ -171,7 +171,7 @@ public class HealthDataTest {
         ParticipantsApi participantsApi = user.getClient(ParticipantsApi.class);
 
         StudyParticipant participant = participantsApi.getUsersParticipantRecord(false).execute().body();
-        participant.setDataGroups(ImmutableList.of("group1"));
+        participant.setDataGroups(ImmutableList.of("group1", "test_user"));
         participant.setSharingScope(SharingScope.SPONSORS_AND_PARTNERS);
         participantsApi.updateUsersParticipantRecord(participant).execute();
     }
@@ -232,7 +232,7 @@ public class HealthDataTest {
         assertNotNull(record.getUploadedOn());
         assertEquals(SharingScope.SPONSORS_AND_PARTNERS, record.getUserSharingScope());
         assertEquals(externalIdentifier, record.getUserExternalId());
-        assertEquals(ImmutableList.of("group1"), record.getUserDataGroups());
+        assertEquals(ImmutableList.of("group1", "test_user"), record.getUserDataGroups());
 
         // createdOn is flattened to UTC server side.
         assertEquals(createdOn.getMillis(), record.getCreatedOn().getMillis());

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
@@ -537,12 +537,11 @@ public class ParticipantsTest {
     
     @Test
     public void getActivityHistory() throws Exception {
-        // Make the user a developer so with one account, we can generate some tasks
         TestUser user = new TestUserHelper.Builder(ParticipantsTest.class)
-                .withRoles(DEVELOPER).withConsentUser(true).isTestUser().createAndSignInUser();
+                .withConsentUser(true).createAndSignInUser();
         ForConsentedUsersApi usersApi = user.getClient(ForConsentedUsersApi.class);
         
-        SchedulesV1Api schedulePlanApi = user.getClient(SchedulesV1Api.class);
+        SchedulesV1Api schedulePlanApi = developer.getClient(SchedulesV1Api.class);
         SchedulePlan plan = Tests.getDailyRepeatingSchedulePlan();
 
         // Set an identifiable label on the activity so we can find the generated activities later.
@@ -599,11 +598,11 @@ public class ParticipantsTest {
     @Test
     public void getActivityHistoryV4() throws Exception {
         TestUser user = new TestUserHelper.Builder(ParticipantsTest.class)
-                .withRoles(DEVELOPER).withConsentUser(true).isTestUser().createAndSignInUser();
+                .withConsentUser(true).createAndSignInUser();
 
         ForConsentedUsersApi usersApi = user.getClient(ForConsentedUsersApi.class);
         
-        SchedulesV1Api schedulePlanApi = user.getClient(SchedulesV1Api.class);
+        SchedulesV1Api schedulePlanApi = developer.getClient(SchedulesV1Api.class);
         SchedulePlan plan = Tests.getDailyRepeatingSchedulePlan();
 
         // Set an identifiable label on the activity so we can find the generated activities later.
@@ -613,7 +612,6 @@ public class ParticipantsTest {
         
         String taskReferentGuid = oneActivity.getTask().getIdentifier();
         oneActivity.setLabel(activityLabel);
-        
         
         GuidVersionHolder planKeys = schedulePlanApi.createSchedulePlan(plan).execute().body();
         try {

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
@@ -537,8 +537,7 @@ public class ParticipantsTest {
     
     @Test
     public void getActivityHistory() throws Exception {
-        TestUser user = new TestUserHelper.Builder(ParticipantsTest.class)
-                .withConsentUser(true).createAndSignInUser();
+        TestUser user = TestUserHelper.createAndSignInUser(ParticipantsTest.class, true);
         ForConsentedUsersApi usersApi = user.getClient(ForConsentedUsersApi.class);
         
         SchedulesV1Api schedulePlanApi = developer.getClient(SchedulesV1Api.class);
@@ -597,8 +596,7 @@ public class ParticipantsTest {
     
     @Test
     public void getActivityHistoryV4() throws Exception {
-        TestUser user = new TestUserHelper.Builder(ParticipantsTest.class)
-                .withConsentUser(true).createAndSignInUser();
+        TestUser user = TestUserHelper.createAndSignInUser(ParticipantsTest.class, true);
 
         ForConsentedUsersApi usersApi = user.getClient(ForConsentedUsersApi.class);
         

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
@@ -57,7 +57,6 @@ import org.sagebionetworks.bridge.rest.model.IdentifierHolder;
 import org.sagebionetworks.bridge.rest.model.IdentifierUpdate;
 import org.sagebionetworks.bridge.rest.model.Message;
 import org.sagebionetworks.bridge.rest.model.Phone;
-import org.sagebionetworks.bridge.rest.model.Role;
 import org.sagebionetworks.bridge.rest.model.SchedulePlan;
 import org.sagebionetworks.bridge.rest.model.ScheduledActivity;
 import org.sagebionetworks.bridge.rest.model.ScheduledActivityList;
@@ -539,7 +538,8 @@ public class ParticipantsTest {
     @Test
     public void getActivityHistory() throws Exception {
         // Make the user a developer so with one account, we can generate some tasks
-        TestUser user = TestUserHelper.createAndSignInUser(ParticipantsTest.class, true, Role.DEVELOPER);
+        TestUser user = new TestUserHelper.Builder(ParticipantsTest.class)
+                .withRoles(DEVELOPER).withConsentUser(true).isTestUser().createAndSignInUser();
         ForConsentedUsersApi usersApi = user.getClient(ForConsentedUsersApi.class);
         
         SchedulesV1Api schedulePlanApi = user.getClient(SchedulesV1Api.class);
@@ -598,7 +598,9 @@ public class ParticipantsTest {
     
     @Test
     public void getActivityHistoryV4() throws Exception {
-        TestUser user = TestUserHelper.createAndSignInUser(ParticipantsTest.class, true, Role.DEVELOPER);
+        TestUser user = new TestUserHelper.Builder(ParticipantsTest.class)
+                .withRoles(DEVELOPER).withConsentUser(true).isTestUser().createAndSignInUser();
+
         ForConsentedUsersApi usersApi = user.getClient(ForConsentedUsersApi.class);
         
         SchedulesV1Api schedulePlanApi = user.getClient(SchedulesV1Api.class);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ReportTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ReportTest.java
@@ -137,7 +137,9 @@ public class ReportTest {
 
     @Test
     public void developerCanCrudParticipantReport() throws Exception {
-        user = TestUserHelper.createAndSignInUser(ReportTest.class, true);
+        user = new TestUserHelper.Builder(ReportTest.class)
+                .withConsentUser(true)
+                .isTestUser().createAndSignInUser();
         
         String userId = user.getSession().getId();
         ParticipantReportsApi reportsApi = developer.getClient(ParticipantReportsApi.class);
@@ -186,7 +188,9 @@ public class ReportTest {
 
     @Test
     public void workerCanCrudParticipantReportByDate() throws Exception {
-        user = TestUserHelper.createAndSignInUser(ReportTest.class, true);
+        user = new TestUserHelper.Builder(ReportTest.class)
+                .withConsentUser(true)
+                .isTestUser().createAndSignInUser();
 
         String healthCode = worker.getClient(ParticipantsApi.class).getParticipantById(user.getSession().getId(),
                 false).execute().body().getHealthCode();
@@ -226,7 +230,9 @@ public class ReportTest {
 
     @Test
     public void workerCanCrudParticipantReportByDateTime() throws Exception {
-        user = TestUserHelper.createAndSignInUser(ReportTest.class, true);
+        user = new TestUserHelper.Builder(ReportTest.class)
+                .withConsentUser(true)
+                .isTestUser().createAndSignInUser();
 
         String healthCode = worker.getClient(ParticipantsApi.class).getParticipantById(user.getSession().getId(),
                 false).execute().body().getHealthCode();
@@ -399,7 +405,10 @@ public class ReportTest {
     
     @Test
     public void userCanCRUDSelfReports() throws Exception {
-        user = TestUserHelper.createAndSignInUser(ReportTest.class, true);
+        user = new TestUserHelper.Builder(ReportTest.class)
+                .withConsentUser(true)
+                .isTestUser().createAndSignInUser();
+
         UsersApi userApi = user.getClient(UsersApi.class);
 
         userApi.saveParticipantReportRecordsV4(reportId, makeReportData(DATETIME1, "foo", "A")).execute();
@@ -459,7 +468,7 @@ public class ReportTest {
         // Just assign an external ID in order to enroll the account in a study
         study2User = new TestUserHelper.Builder(ReportTest.class).withConsentUser(false)
                 .withExternalIds(ImmutableMap.of(STUDY_ID_2, Tests.randomIdentifier(ReportTest.class)))
-                .createAndSignInUser();
+                .isTestUser().createAndSignInUser();
         StudyReportsApi reportsApi = study2User.getClient(StudyReportsApi.class);
         ReportIndex index = reportsApi.getStudyReportIndex(reportId).execute().body();
         assertTrue(index.getStudyIds().contains(STUDY_ID_1));
@@ -507,7 +516,7 @@ public class ReportTest {
         // the user anyway.
         study2User = new TestUserHelper.Builder(ReportTest.class).withConsentUser(false)
                 .withExternalIds(ImmutableMap.of(STUDY_ID_2, Tests.randomIdentifier(ReportTest.class)))
-                .createAndSignInUser();
+                .isTestUser().createAndSignInUser();
         
         String healthCode = worker.getClient(ParticipantsApi.class)
                 .getParticipantById(study2User.getUserId(), false).execute().body().getHealthCode();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ReportTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ReportTest.java
@@ -188,8 +188,7 @@ public class ReportTest {
 
     @Test
     public void workerCanCrudParticipantReportByDate() throws Exception {
-        user = new TestUserHelper.Builder(ReportTest.class)
-                .withConsentUser(true).createAndSignInUser();
+        user = TestUserHelper.createAndSignInUser(ReportTest.class, true);
 
         String healthCode = worker.getClient(ParticipantsApi.class).getParticipantById(user.getSession().getId(),
                 false).execute().body().getHealthCode();
@@ -229,8 +228,7 @@ public class ReportTest {
 
     @Test
     public void workerCanCrudParticipantReportByDateTime() throws Exception {
-        user = new TestUserHelper.Builder(ReportTest.class)
-                .withConsentUser(true).createAndSignInUser();
+        user = TestUserHelper.createAndSignInUser(ReportTest.class, true);
 
         String healthCode = worker.getClient(ParticipantsApi.class).getParticipantById(user.getSession().getId(),
                 false).execute().body().getHealthCode();
@@ -403,8 +401,7 @@ public class ReportTest {
     
     @Test
     public void userCanCRUDSelfReports() throws Exception {
-        user = new TestUserHelper.Builder(ReportTest.class)
-                .withConsentUser(true).createAndSignInUser();
+        user = TestUserHelper.createAndSignInUser(ReportTest.class, true);
 
         UsersApi userApi = user.getClient(UsersApi.class);
 

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserParticipantTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserParticipantTest.java
@@ -156,7 +156,7 @@ public class UserParticipantTest {
         developer.signInAgain();
 
         participant = usersApi.getUsersParticipantRecord(false).execute().body();
-        assertTrue(participant.getDataGroups().isEmpty());
+        assertEquals(participant.getDataGroups(), ImmutableList.of("test_user"));
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserParticipantTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserParticipantTest.java
@@ -108,10 +108,11 @@ public class UserParticipantTest {
         
         TestUser user = new TestUserHelper.Builder(UserParticipantTest.class)
                 .withExternalIds(ImmutableMap.of(STUDY_ID_1, externalId1)).createAndSignInUser();
+        
         try {
             ForConsentedUsersApi usersApi = user.getClient(ForConsentedUsersApi.class);
             StudyParticipant participant = usersApi.getUsersParticipantRecord(false).execute().body();
-            assertEquals(participant.getExternalIds().get(STUDY_ID_1), externalId1);
+            assertEquals(externalId1, participant.getExternalIds().get(STUDY_ID_1));
 
             UserSessionInfo session = usersApi.updateUsersParticipantRecord(participant).execute().body();
             assertEquals(externalId1, session.getExternalIds().get(STUDY_ID_1));
@@ -125,7 +126,7 @@ public class UserParticipantTest {
             usersApi.updateUsersParticipantRecord(participant).execute();
             
             StudyParticipant retValue = usersApi.getUsersParticipantRecord(false).execute().body();
-            assertEquals(retValue.getExternalIds().get(STUDY_ID_1), externalId1);
+            assertEquals(externalId1, retValue.getExternalIds().get(STUDY_ID_1));
             assertNull(retValue.getExternalIds().get(STUDY_ID_2));
         } finally {
             user.signOutAndDeleteUser();


### PR DESCRIPTION
BRIDGE-3053

Developers must now operate on accounts that are marked as test accounts. For some calls, this wasn't previously necessary.