### PR TITLE
Updating tests

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AppTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AppTest.java
@@ -10,6 +10,7 @@ import static org.sagebionetworks.bridge.rest.model.ActivityEventUpdateType.FUTU
 import static org.sagebionetworks.bridge.rest.model.ActivityEventUpdateType.MUTABLE;
 import static org.sagebionetworks.bridge.rest.model.Role.DEVELOPER;
 import static org.sagebionetworks.bridge.rest.model.Role.RESEARCHER;
+import static org.sagebionetworks.bridge.sdk.integration.Tests.assertListsEqualIgnoringOrder;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_ID;
 import static org.sagebionetworks.repo.model.util.ModelConstants.ENTITY_ADMIN_ACCESS_PERMISSIONS;
 
@@ -259,7 +260,7 @@ public class AppTest {
         assertEquals("consentNotificationEmail should be equal", app.getConsentNotificationEmail(), newApp.getConsentNotificationEmail());
         assertEquals("userProfileAttributes should be equal", app.getUserProfileAttributes(), newApp.getUserProfileAttributes());
         assertEquals("taskIdentifiers should be equal", app.getTaskIdentifiers(), newApp.getTaskIdentifiers());
-        assertTrue("dataGroups should be equal", Tests.assertListsEqualIgnoringOrder(app.getDataGroups(), newApp.getDataGroups()));
+        assertListsEqualIgnoringOrder(app.getDataGroups(), newApp.getDataGroups());
         assertEquals("customEvents should be equal", app.getCustomEvents(), newApp.getCustomEvents());
         assertEquals("customEvents should be equal to 2", app.getCustomEvents().size(), 2);
         assertEquals(app.getCustomEvents().get("event1"), MUTABLE);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
@@ -13,13 +13,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Predicate;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
@@ -327,13 +326,8 @@ public class Tests {
         assertEquals(expected.getZone().getOffset(expected), actual.getZone().getOffset(actual));
     }
 
-    public static <T> boolean assertListsEqualIgnoringOrder(List<T> list1, List<T> list2) {
-        if (list1.size() != list2.size()) {
-            return false;
-        }
-        Set<T> setA = Sets.newHashSet(list1);
-        Set<T> setB = Sets.newHashSet(list2);
-        return Sets.difference(setA, setB).isEmpty();
+    public static <T> void assertListsEqualIgnoringOrder(List<T> list1, List<T> list2) {
+        assertEquals(ImmutableSet.copyOf(list1), ImmutableSet.copyOf(list2));
     }
     
     // Adapted from http://plexus.codehaus.org/plexus-utils which seems to be defunct.

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserParticipantTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserParticipantTest.java
@@ -11,7 +11,9 @@ import static org.sagebionetworks.bridge.sdk.integration.Tests.assertListsEqualI
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -40,15 +42,15 @@ public class UserParticipantTest {
     private static TestUser researcher;
     private static TestUser consentedUser;
 
-    @BeforeClass
-    public static void before() throws Exception {
+    @Before
+    public void before() throws Exception {
         developer = TestUserHelper.createAndSignInUser(UserParticipantTest.class, true, Role.DEVELOPER);
         researcher = TestUserHelper.createAndSignInUser(UserParticipantTest.class, true, Role.RESEARCHER);
         consentedUser = TestUserHelper.createAndSignInUser(UserParticipantTest.class, true);
     }
 
-    @AfterClass
-    public static void after() throws Exception {
+    @After
+    public void after() throws Exception {
         if (developer != null) {
             developer.signOutAndDeleteUser();    
         }
@@ -148,7 +150,7 @@ public class UserParticipantTest {
         developer.signInAgain();
         
         participant = usersApi.getUsersParticipantRecord(false).execute().body();
-        assertListsEqualIgnoringOrder(ImmutableList.of("sdk-int-1", "sdk-int-2", "test_user"), participant.getDataGroups());
+        assertListsEqualIgnoringOrder(dataGroups, participant.getDataGroups());
 
         // now clear the values, it should be possible to remove them.
         participant.setDataGroups(ImmutableList.of());
@@ -158,13 +160,12 @@ public class UserParticipantTest {
         developer.signInAgain();
 
         participant = usersApi.getUsersParticipantRecord(false).execute().body();
-        assertListsEqualIgnoringOrder(ImmutableList.of("test_user"), participant.getDataGroups());
+        assertListsEqualIgnoringOrder(ImmutableList.of(), participant.getDataGroups());
     }
 
     @Test
     public void canUpdateDataGroupsDoesNotOverrideTestFlag() throws Exception {
-        // Developer in this test is not a test user.
-        
+        // Developer in this test is set as a test user.
         List<String> dataGroups = ImmutableList.of("sdk-int-1", "sdk-int-2", "test_user");
 
         ForConsentedUsersApi usersApi = developer.getClient(ForConsentedUsersApi.class);
@@ -176,10 +177,12 @@ public class UserParticipantTest {
         developer.signOut();
         developer.signInAgain();
         
+        // Because this is only a developer, their own account is modified to be a test account
+        // on update.
         participant = usersApi.getUsersParticipantRecord(false).execute().body();
         assertListsEqualIgnoringOrder(dataGroups, participant.getDataGroups());
 
-        // now clear the values, it should be possible to remove them.
+        // now clear the values, it should be possible to remove all but the test_user.
         participant.setDataGroups(ImmutableList.of());
         usersApi.updateUsersParticipantRecord(participant).execute();
         


### PR DESCRIPTION
Needed to recreate the developer on each test, in order for the tests to make sense (in fact, this test initially failed either because of a late change on my part, or because the order of the tests as executed on Jenkins was difference). Tests now clarify that test_user is not and cannot be removed.