### PR TITLE
Configs to assessments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.22.26</version>
+            <version>0.22.27</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.22.30</version>
+            <version>0.22.31</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.22.27</version>
+            <version>0.22.29</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AppConfigTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AppConfigTest.java
@@ -251,8 +251,10 @@ public class AppConfigTest {
         AssessmentReference retAssessmentRef = resolvedAppConfig.getAssessmentReferences().get(0);
         assertEquals(assessmentGuid, retAssessmentRef.getGuid());
         assertEquals(id, retAssessmentRef.getId());
-        assertNull(retAssessmentRef.getSharedId());
+        assertNull(retAssessmentRef.getOriginSharedId());
         assertTrue(retAssessmentRef.getConfigHref().contains("/v1/assessments/" + assessmentGuid + "/config"));
+        // TODO: find expected appId
+        assertEquals("api", retAssessmentRef.getAppId());
 
         Tests.setVariableValueInObject(firstOneRetrieved.getSurveyReferences().get(0), "href", null);
         assertEquals(appConfig.getLabel(), firstOneRetrieved.getLabel());

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AppConfigTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AppConfigTest.java
@@ -25,6 +25,7 @@ import org.sagebionetworks.bridge.rest.RestUtils;
 import org.sagebionetworks.bridge.rest.api.AppConfigsApi;
 import org.sagebionetworks.bridge.rest.api.AppsApi;
 import org.sagebionetworks.bridge.rest.api.AssessmentsApi;
+import org.sagebionetworks.bridge.rest.api.SharedAssessmentsApi;
 import org.sagebionetworks.bridge.rest.api.FilesApi;
 import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
@@ -80,13 +81,18 @@ public class AppConfigTest {
     private SurveysApi surveysApi;
     private FilesApi filesApi;
     private AssessmentsApi assessmentsApi;
+    private SharedAssessmentsApi sharedAssessmentsApi;
     private List<String> configsToDelete = new ArrayList<>();
     
     private GuidCreatedOnVersionHolder surveyKeys;
     private UploadSchema schemaKeys;
     private GuidVersionHolder fileKeys;
     private String assessmentGuid;
+    private String localAssessmentGuid;
+    private String sharedAssessmentGuid;
     private AppConfigElement element;
+    private String appId;
+    private String sharedAppId;
     
     @Before
     public void before() throws IOException {
@@ -98,11 +104,15 @@ public class AppConfigTest {
         admin.getClient(OrganizationsApi.class).addMember(ORG_ID_1, developer.getUserId()).execute();
 
         adminApi = admin.getClient(ForAdminsApi.class);
+        sharedAssessmentsApi = admin.getClient(SharedAssessmentsApi.class);
         appConfigsApi = developer.getClient(AppConfigsApi.class);
         schemasApi = developer.getClient(UploadSchemasApi.class);
         surveysApi = developer.getClient(SurveysApi.class);
         filesApi = developer.getClient(FilesApi.class);
         assessmentsApi = developer.getClient(AssessmentsApi.class);
+
+        appId = admin.getAppId();
+        sharedAppId = "shared";
 
         // App configs with no criteria will conflict with the run of this test. Set the range on these
         // for Android to 1-1.
@@ -154,7 +164,21 @@ public class AppConfigTest {
             adminApi.deleteAssessment(assessmentGuid, true).execute();
         }
     }
-    
+
+    @After
+    public void deleteLocalAssessment() throws Exception {
+        if (localAssessmentGuid != null) {
+            adminApi.deleteAssessment(localAssessmentGuid, true).execute();
+        }
+    }
+
+    @After
+    public void deleteSharedAssessment() throws Exception {
+        if (sharedAssessmentGuid != null) {
+            sharedAssessmentsApi.deleteSharedAssessment(sharedAssessmentGuid, true).execute();
+        }
+    }
+
     @After
     public void deleteAppConfigElement() throws IOException {
         if (element != null) {
@@ -188,10 +212,27 @@ public class AppConfigTest {
                 .normingStatus("Not normed")
                 .osName("Both")
                 .ownerId(ORG_ID_1);
-        
+
         Assessment assessment = assessmentsApi.createAssessment(unsavedAssessment).execute().body();
         assessmentGuid = assessment.getGuid();
-        
+
+        String localAssessmentId = randomIdentifier(AssessmentTest.class);
+        Assessment unsavedLocalAssessment = new Assessment()
+                .identifier(localAssessmentId)
+                .title("localTitle")
+                .osName("Both")
+                .ownerId(ORG_ID_1);
+
+        Assessment localAssessment = assessmentsApi.createAssessment(unsavedLocalAssessment).execute().body();
+        localAssessmentGuid = localAssessment.getGuid();
+
+        String sharedAssessmentId = randomIdentifier(AssessmentTest.class);
+        assessmentsApi.publishAssessment(localAssessmentGuid, sharedAssessmentId).execute();
+
+        Assessment sharedAssessment = sharedAssessmentsApi.getSharedAssessmentById(sharedAssessmentId, 1L)
+                .execute().body();
+        sharedAssessmentGuid = sharedAssessment.getGuid();
+
         FileMetadata meta = new FileMetadata();
         meta.setName("test file");
         meta.setDisposition(INLINE);
@@ -237,7 +278,9 @@ public class AppConfigTest {
         appConfig.criteria(criteria);
         appConfig.surveyReferences(ImmutableList.of(surveyRef1));
         appConfig.fileReferences(ImmutableList.of(fileRef));
-        appConfig.assessmentReferences(ImmutableList.of(new AssessmentReference().guid(assessmentGuid)));
+        appConfig.assessmentReferences(ImmutableList.of(
+                new AssessmentReference().guid(assessmentGuid).appId(appId),
+                new AssessmentReference().guid(sharedAssessmentGuid).appId(sharedAppId)));
         
         // Create
         GuidVersionHolder holder = appConfigsApi.createAppConfig(appConfig).execute().body();
@@ -250,11 +293,18 @@ public class AppConfigTest {
                 .getConfigForApp(user.getAppId()).execute().body();
         AssessmentReference retAssessmentRef = resolvedAppConfig.getAssessmentReferences().get(0);
         assertEquals(assessmentGuid, retAssessmentRef.getGuid());
+        assertEquals(appId, retAssessmentRef.getAppId());
         assertEquals(id, retAssessmentRef.getId());
         assertNull(retAssessmentRef.getOriginSharedId());
         assertTrue(retAssessmentRef.getConfigHref().contains("/v1/assessments/" + assessmentGuid + "/config"));
-        // TODO: find expected appId
-        assertEquals("api", retAssessmentRef.getAppId());
+
+        AssessmentReference retSharedAssessmentRef = resolvedAppConfig.getAssessmentReferences().get(1);
+        assertEquals(sharedAssessmentGuid, retSharedAssessmentRef.getGuid());
+        assertEquals(sharedAppId, retSharedAssessmentRef.getAppId());
+        assertEquals(sharedAssessmentId, retSharedAssessmentRef.getId());
+        assertNull(retSharedAssessmentRef.getOriginSharedId());
+        assertTrue(retSharedAssessmentRef.getConfigHref()
+                .contains("/v1/sharedassessments/" + sharedAssessmentGuid + "/config"));
 
         Tests.setVariableValueInObject(firstOneRetrieved.getSurveyReferences().get(0), "href", null);
         assertEquals(appConfig.getLabel(), firstOneRetrieved.getLabel());
@@ -280,7 +330,10 @@ public class AppConfigTest {
         appConfig.setFileReferences(ImmutableList.of());
         appConfig.setGuid(holder.getGuid());
         appConfig.setVersion(holder.getVersion());
-        
+
+        appConfig.setAssessmentReferences(ImmutableList.of(
+                new AssessmentReference().guid(localAssessmentGuid).appId(appId)));
+
         // Update it.
         holder = appConfigsApi.updateAppConfig(appConfig.getGuid(), appConfig).execute().body();
         appConfig.setGuid(holder.getGuid());
@@ -296,7 +349,17 @@ public class AppConfigTest {
         assertEquals(secondOneRetrieved.getCreatedOn().toString(), firstOneRetrieved.getCreatedOn().toString());
         assertNotEquals(secondOneRetrieved.getModifiedOn().toString(), firstOneRetrieved.getModifiedOn().toString());
         assertTrue(secondOneRetrieved.getFileReferences().isEmpty());
-        
+        assertEquals(1, secondOneRetrieved.getAssessmentReferences().size());
+
+        // Verify that the local assessment reference includes its origin shared assessment id
+        AssessmentReference retLocalAssessmentRef = secondOneRetrieved.getAssessmentReferences().get(0);
+        assertEquals(localAssessmentGuid, retLocalAssessmentRef.getGuid());
+        assertEquals(appId, retLocalAssessmentRef.getAppId());
+        assertEquals(localAssessmentId, retLocalAssessmentRef.getId());
+        assertEquals(sharedAssessmentId, retLocalAssessmentRef.getOriginSharedId());
+        assertTrue(retLocalAssessmentRef.getConfigHref()
+                .contains("/v1/assessments/" + localAssessmentGuid + "/config"));
+
         // You can get it as the user
         AppConfig userAppConfig = studiesApi.getConfigForApp(developer.getAppId()).execute().body();
         assertNotNull(userAppConfig);


### PR DESCRIPTION
For Bridge-2950.

- Adding tests for including shared assessments in the app config's assessment references.