### PR TITLE
Updating tests now that org admins cannot see participant accounts

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AccountsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AccountsTest.java
@@ -241,8 +241,7 @@ public class AccountsTest {
     @Test
     public void nonAdminCannotViewNote() throws Exception {
         String email = IntegTestUtils.makeEmail(AccountsTest.class);
-        SignUp signUp = new SignUp().appId(TEST_APP_ID).email(email).password(PASSWORD).consent(true)
-                .orgMembership(SAGE_ID);
+        SignUp signUp = new SignUp().appId(TEST_APP_ID).email(email).password(PASSWORD).consent(true);
 
         emailUserId = admin.getClient(ForAdminsApi.class).createUser(signUp).execute().body().getId();
 
@@ -264,8 +263,7 @@ public class AccountsTest {
     @Test
     public void nonAdminCannotUpdateNote() throws Exception {
         String email = IntegTestUtils.makeEmail(AccountsTest.class);
-        SignUp signUp = new SignUp().appId(TEST_APP_ID).email(email).password(PASSWORD).consent(true)
-                .orgMembership(SAGE_ID);
+        SignUp signUp = new SignUp().appId(TEST_APP_ID).email(email).password(PASSWORD).consent(true);
 
         emailUserId = admin.getClient(ForAdminsApi.class).createUser(signUp).execute().body().getId();
 


### PR DESCRIPTION
Tests of note functionality were using org admin to manipulate an account that is a participant account. Switched to use of a study coordinator, who can add notes to this record. (This might change, but that's true for now).