### PR TITLE
Change tests to use methods that are on role-based APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.22.33</version>
+            <version>0.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AppConfigTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AppConfigTest.java
@@ -26,9 +26,9 @@ import org.sagebionetworks.bridge.rest.api.AppConfigsApi;
 import org.sagebionetworks.bridge.rest.api.AppsApi;
 import org.sagebionetworks.bridge.rest.api.AssessmentsApi;
 import org.sagebionetworks.bridge.rest.api.SharedAssessmentsApi;
-import org.sagebionetworks.bridge.rest.api.FilesApi;
 import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
+import org.sagebionetworks.bridge.rest.api.HostedFilesApi;
 import org.sagebionetworks.bridge.rest.api.OrganizationsApi;
 import org.sagebionetworks.bridge.rest.api.PublicApi;
 import org.sagebionetworks.bridge.rest.api.SurveysApi;
@@ -79,7 +79,7 @@ public class AppConfigTest {
     private AppConfigsApi appConfigsApi;
     private UploadSchemasApi schemasApi;
     private SurveysApi surveysApi;
-    private FilesApi filesApi;
+    private HostedFilesApi hostedFilesApi;
     private AssessmentsApi assessmentsApi;
     private SharedAssessmentsApi sharedAssessmentsApi;
     private List<String> configsToDelete = new ArrayList<>();
@@ -108,7 +108,7 @@ public class AppConfigTest {
         appConfigsApi = developer.getClient(AppConfigsApi.class);
         schemasApi = developer.getClient(UploadSchemasApi.class);
         surveysApi = developer.getClient(SurveysApi.class);
-        filesApi = developer.getClient(FilesApi.class);
+        hostedFilesApi = developer.getClient(HostedFilesApi.class);
         assessmentsApi = developer.getClient(AssessmentsApi.class);
 
         appId = admin.getAppId();
@@ -236,12 +236,12 @@ public class AppConfigTest {
         FileMetadata meta = new FileMetadata();
         meta.setName("test file");
         meta.setDisposition(INLINE);
-        fileKeys = filesApi.createFile(meta).execute().body();
+        fileKeys = hostedFilesApi.createFile(meta).execute().body();
         
         File file = new File("src/test/resources/file-test/test.pdf");
-        RestUtils.uploadHostedFileToS3(filesApi, fileKeys.getGuid(), file);
+        RestUtils.uploadHostedFileToS3(hostedFilesApi, fileKeys.getGuid(), file);
         
-        FileRevisionList list = filesApi.getFileRevisions(fileKeys.getGuid(), 0, 5).execute().body();
+        FileRevisionList list = hostedFilesApi.getFileRevisions(fileKeys.getGuid(), 0, 5).execute().body();
         FileRevision revision = list.getItems().get(0);
         FileReference fileRef = new FileReference().guid(revision.getFileGuid()).createdOn(revision.getCreatedOn());
         

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/CompoundActivityDefinitionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/CompoundActivityDefinitionTest.java
@@ -15,7 +15,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.sagebionetworks.bridge.rest.api.CompoundActivityDefinitionsApi;
+import org.sagebionetworks.bridge.rest.api.ForDevelopersApi;
 import org.sagebionetworks.bridge.rest.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.rest.model.CompoundActivityDefinition;
 import org.sagebionetworks.bridge.rest.model.Role;
@@ -34,7 +34,7 @@ public class CompoundActivityDefinitionTest {
 
     private static final String TASK_ID_PREFIX = "test-task-";
 
-    private static CompoundActivityDefinitionsApi compoundActivityDefinitionsApi;
+    private static ForDevelopersApi forDevelopersApi;
     private static TestUserHelper.TestUser developer;
 
     private String taskId;
@@ -42,7 +42,7 @@ public class CompoundActivityDefinitionTest {
     @BeforeClass
     public static void beforeClass() throws Exception {
         developer = TestUserHelper.createAndSignInUser(UploadSchemaTest.class, false, Role.DEVELOPER);
-        compoundActivityDefinitionsApi = developer.getClient(CompoundActivityDefinitionsApi.class);
+        forDevelopersApi = developer.getClient(ForDevelopersApi.class);
     }
 
     @Before
@@ -63,14 +63,14 @@ public class CompoundActivityDefinitionTest {
         CompoundActivityDefinition defToCreate = new CompoundActivityDefinition().taskId(taskId)
                 .schemaList(SCHEMA_LIST).surveyList(SURVEY_LIST);
 
-        CompoundActivityDefinition createdDef = compoundActivityDefinitionsApi.createCompoundActivityDefinition(
+        CompoundActivityDefinition createdDef = forDevelopersApi.createCompoundActivityDefinition(
                 defToCreate).execute().body();
         assertSchemaList(createdDef.getSchemaList());
         assertSurveyList(createdDef.getSurveyList());
         assertEquals(taskId, createdDef.getTaskId());
 
         // get the created def and validate
-        CompoundActivityDefinition gettedCreatedDef = compoundActivityDefinitionsApi.getCompoundActivityDefinition(
+        CompoundActivityDefinition gettedCreatedDef = forDevelopersApi.getCompoundActivityDefinition(
                 taskId).execute().body();
         assertSchemaList(gettedCreatedDef.getSchemaList());
         assertSurveyList(gettedCreatedDef.getSurveyList());
@@ -79,25 +79,25 @@ public class CompoundActivityDefinitionTest {
         // Update the def to have no surveys.
         CompoundActivityDefinition defToUpdate = gettedCreatedDef.surveyList(ImmutableList.of());
 
-        CompoundActivityDefinition updatedDef = compoundActivityDefinitionsApi.updateCompoundActivityDefinition(taskId,
+        CompoundActivityDefinition updatedDef = forDevelopersApi.updateCompoundActivityDefinition(taskId,
                 defToUpdate).execute().body();
         assertSchemaList(updatedDef.getSchemaList());
         assertTrue(updatedDef.getSurveyList().isEmpty());
         assertEquals(taskId, updatedDef.getTaskId());
 
         // get the updated def and validate
-        CompoundActivityDefinition gettedUpdatedDef = compoundActivityDefinitionsApi.getCompoundActivityDefinition(
+        CompoundActivityDefinition gettedUpdatedDef = forDevelopersApi.getCompoundActivityDefinition(
                 taskId).execute().body();
         assertSchemaList(gettedUpdatedDef.getSchemaList());
         assertTrue(gettedUpdatedDef.getSurveyList().isEmpty());
         assertEquals(taskId, gettedUpdatedDef.getTaskId());
 
         // delete
-        compoundActivityDefinitionsApi.deleteCompoundActivityDefinition(taskId).execute();
+        forDevelopersApi.deleteCompoundActivityDefinition(taskId).execute();
 
         // If you get the task, it throws.
         try {
-            compoundActivityDefinitionsApi.getCompoundActivityDefinition(taskId).execute();
+            forDevelopersApi.getCompoundActivityDefinition(taskId).execute();
             fail("expected exception");
         } catch (EntityNotFoundException ex) {
             // expected exception
@@ -114,16 +114,16 @@ public class CompoundActivityDefinitionTest {
             taskId1 = taskId + "1";
             CompoundActivityDefinition def1 = new CompoundActivityDefinition().taskId(taskId1).schemaList(SCHEMA_LIST)
                     .surveyList(SURVEY_LIST);
-            compoundActivityDefinitionsApi.createCompoundActivityDefinition(def1).execute();
+            forDevelopersApi.createCompoundActivityDefinition(def1).execute();
 
             taskId2 = taskId + "2";
             CompoundActivityDefinition def2 = new CompoundActivityDefinition().taskId(taskId2).schemaList(SCHEMA_LIST)
                     .surveyList(SURVEY_LIST);
-            compoundActivityDefinitionsApi.createCompoundActivityDefinition(def2).execute();
+            forDevelopersApi.createCompoundActivityDefinition(def2).execute();
 
             // Test list. Since there might be other defs from other tests, page through the defs to find the ones
             // corresponding to the test.
-            List<CompoundActivityDefinition> defList = compoundActivityDefinitionsApi
+            List<CompoundActivityDefinition> defList = forDevelopersApi
                     .getAllCompoundActivityDefinitions().execute().body().getItems();
             Map<String, CompoundActivityDefinition> defsByTaskId = Maps.uniqueIndex(defList,
                     CompoundActivityDefinition::getTaskId);
@@ -140,13 +140,13 @@ public class CompoundActivityDefinitionTest {
         } finally {
             // clean up defs
             try {
-                compoundActivityDefinitionsApi.deleteCompoundActivityDefinition(taskId1).execute();
+                forDevelopersApi.deleteCompoundActivityDefinition(taskId1).execute();
             } catch (RuntimeException ex) {
                 // squelch error
             }
 
             try {
-                compoundActivityDefinitionsApi.deleteCompoundActivityDefinition(taskId2).execute();
+                forDevelopersApi.deleteCompoundActivityDefinition(taskId2).execute();
             } catch (RuntimeException ex) {
                 // squelch error
             }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/FileTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/FileTest.java
@@ -16,9 +16,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.rest.RestUtils;
-import org.sagebionetworks.bridge.rest.api.FilesApi;
 import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ForDevelopersApi;
+import org.sagebionetworks.bridge.rest.api.HostedFilesApi;
 import org.sagebionetworks.bridge.rest.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.rest.model.FileMetadata;
 import org.sagebionetworks.bridge.rest.model.FileMetadataList;
@@ -149,9 +149,9 @@ public class FileTest {
             metadata.setGuid(keys.getGuid());
             metadata.setVersion(keys.getVersion());
     
-            FilesApi filesApi = developer.getClient(FilesApi.class);
+            HostedFilesApi hostedFilesApi = developer.getClient(HostedFilesApi.class);
             File file = new File("src/test/resources/file-test/test.pdf");
-            String url = RestUtils.uploadHostedFileToS3(filesApi, metadata.getGuid(), file);
+            String url = RestUtils.uploadHostedFileToS3(hostedFilesApi, metadata.getGuid(), file);
             
             FileRevisionList list = devsApi.getFileRevisions(metadata.getGuid(), 0, 5).execute().body();
             FileRevision rev = list.getItems().get(0);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/IntentToParticipateTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/IntentToParticipateTest.java
@@ -79,8 +79,7 @@ public class IntentToParticipateTest {
             SignUp signUp = new SignUp()
                     .appId(TEST_APP_ID)
                     .phone(IntegTestUtils.PHONE)
-                    .password(Tests.PASSWORD)
-                    .checkForConsent(true);
+                    .password(Tests.PASSWORD);
             user = new TestUserHelper.Builder(IntentToParticipate.class)
                 .withSignUp(signUp)
                 .withConsentUser(false) // important, the ITP must do this.
@@ -145,8 +144,7 @@ public class IntentToParticipateTest {
             SignUp signUp = new SignUp()
                     .appId(TEST_APP_ID)
                     .email(email)
-                    .password(Tests.PASSWORD)
-                    .checkForConsent(true);
+                    .password(Tests.PASSWORD);
             user = new TestUserHelper.Builder(IntentToParticipate.class)
                 .withSignUp(signUp)
                 .withConsentUser(false) // important, the ITP must do this.

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantDataTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantDataTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
 import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
-import org.sagebionetworks.bridge.rest.api.UsersApi;
 import org.sagebionetworks.bridge.rest.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.rest.model.ForwardCursorStringList;
 import org.sagebionetworks.bridge.rest.model.ParticipantData;
@@ -67,7 +66,7 @@ public class ParticipantDataTest {
 
     @Test
     public void userCanCrudSelfData() throws IOException {
-        UsersApi userApi = user.getClient(UsersApi.class);
+        ForConsentedUsersApi userApi = user.getClient(ForConsentedUsersApi.class);
 
         ParticipantData participantData1 = createParticipantData("foo", "A");
         ParticipantData participantData2 = createParticipantData("bar", "B");

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantsTest.java
@@ -106,7 +106,8 @@ public class ParticipantsTest {
         admin = TestUserHelper.getSignedInAdmin();
         developer = TestUserHelper.createAndSignInUser(ParticipantsTest.class, false, DEVELOPER);
         researcher = TestUserHelper.createAndSignInUser(ParticipantsTest.class, true, RESEARCHER);
-        studyCoordinator = TestUserHelper.createAndSignInUser(ParticipantsTest.class, true, STUDY_COORDINATOR);
+        studyCoordinator = TestUserHelper.createAndSignInUser(ParticipantsTest.class, false, STUDY_COORDINATOR);
+        // Put the study coordinator in org1 so they only have access to study1
         admin.getClient(OrganizationsApi.class).removeMember(SAGE_ID, studyCoordinator.getUserId()).execute();
         admin.getClient(OrganizationsApi.class).addMember(ORG_ID_1, studyCoordinator.getUserId()).execute();
         
@@ -145,11 +146,11 @@ public class ParticipantsTest {
     
     @Test
     public void canGetParticipantRoster() throws Exception {
-        ParticipantsApi participantsApi = researcher.getClient(ParticipantsApi.class);
+        ForResearchersApi researchersApi = researcher.getClient(ForResearchersApi.class);
         
         ParticipantRosterRequest request = new ParticipantRosterRequest().password("Test1111");
         
-        Message message = participantsApi.requestParticipantRoster(request).execute().body();
+        Message message = researchersApi.requestParticipantRoster(request).execute().body();
         assertEquals("Download initiated.", message.getMessage());
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ReportTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ReportTest.java
@@ -33,7 +33,6 @@ import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
 import org.sagebionetworks.bridge.rest.api.ParticipantReportsApi;
 import org.sagebionetworks.bridge.rest.api.ParticipantsApi;
 import org.sagebionetworks.bridge.rest.api.StudyReportsApi;
-import org.sagebionetworks.bridge.rest.api.UsersApi;
 import org.sagebionetworks.bridge.rest.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.rest.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.rest.exceptions.InvalidEntityException;
@@ -403,7 +402,7 @@ public class ReportTest {
     public void userCanCRUDSelfReports() throws Exception {
         user = TestUserHelper.createAndSignInUser(ReportTest.class, true);
 
-        UsersApi userApi = user.getClient(UsersApi.class);
+        ForConsentedUsersApi userApi = user.getClient(ForConsentedUsersApi.class);
 
         userApi.saveParticipantReportRecordsV4(reportId, makeReportData(DATETIME1, "foo", "A")).execute();
         userApi.saveParticipantReportRecordsV4(reportId, makeReportData(DATETIME2, "bar", "B")).execute();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduledActivityAutoResolutionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduledActivityAutoResolutionTest.java
@@ -16,7 +16,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.rest.api.ActivitiesApi;
-import org.sagebionetworks.bridge.rest.api.CompoundActivityDefinitionsApi;
+import org.sagebionetworks.bridge.rest.api.ForDevelopersApi;
 import org.sagebionetworks.bridge.rest.api.SchedulesV1Api;
 import org.sagebionetworks.bridge.rest.api.SurveysApi;
 import org.sagebionetworks.bridge.rest.api.UploadSchemasApi;
@@ -57,7 +57,7 @@ public class ScheduledActivityAutoResolutionTest {
             .name("record.json.test-field").type(UploadFieldType.STRING).maxLength(10);
     private static final String TASK_ID = "task:AAA";
 
-    private static CompoundActivityDefinitionsApi compoundActivityDefinitionsApi;
+    private static ForDevelopersApi forDevelopersApi;
     private static SchedulesV1Api schedulePlanApi;
     private static SurveysApi adminSurveyApi;
     private static SurveysApi surveyApi;
@@ -78,7 +78,7 @@ public class ScheduledActivityAutoResolutionTest {
         // init users and clients
         developer = TestUserHelper.createAndSignInUser(ScheduledActivityAutoResolutionTest.class, false,
                 Role.DEVELOPER);
-        compoundActivityDefinitionsApi = developer.getClient(CompoundActivityDefinitionsApi.class);
+        forDevelopersApi = developer.getClient(ForDevelopersApi.class);
         schedulePlanApi = developer.getClient(SchedulesV1Api.class);
         adminSurveyApi = TestUserHelper.getSignedInAdmin().getClient(SurveysApi.class);
         surveyApi = developer.getClient(SurveysApi.class);
@@ -147,7 +147,7 @@ public class ScheduledActivityAutoResolutionTest {
 
         // Delete compound activity, if any
         if (compoundTaskIdToDelete != null) {
-            compoundActivityDefinitionsApi.deleteCompoundActivityDefinition(compoundTaskIdToDelete).execute();
+            forDevelopersApi.deleteCompoundActivityDefinition(compoundTaskIdToDelete).execute();
         }
 
         // Deleting surveys requires an admin
@@ -259,9 +259,8 @@ public class ScheduledActivityAutoResolutionTest {
         SurveyReference surveyRef = new SurveyReference().guid(surveyKeys.getGuid()).identifier(surveyId);
         CompoundActivityDefinition compoundActivityDefinition = new CompoundActivityDefinition()
                 .addSchemaListItem(schemaRef).addSurveyListItem(surveyRef).taskId(compoundTaskId);
-        CompoundActivityDefinitionsApi compoundActivityDefinitionsApi = developer.getClient(
-                CompoundActivityDefinitionsApi.class);
-        compoundActivityDefinitionsApi.createCompoundActivityDefinition(compoundActivityDefinition).execute();
+        ForDevelopersApi forDevelopersApi = developer.getClient(ForDevelopersApi.class);
+        forDevelopersApi.createCompoundActivityDefinition(compoundActivityDefinition).execute();
         compoundTaskIdToDelete = compoundTaskId;
 
         // Similarly, create a schedule plan with a compound activity ref.
@@ -291,10 +290,10 @@ public class ScheduledActivityAutoResolutionTest {
         }
 
         // Update the compound activity definition. Simplest update, just remove the survey and leave the schema.
-        CompoundActivityDefinition defToUpdate = compoundActivityDefinitionsApi.getCompoundActivityDefinition(
+        CompoundActivityDefinition defToUpdate = forDevelopersApi.getCompoundActivityDefinition(
                 compoundTaskId).execute().body();
         defToUpdate.setSurveyList(ImmutableList.of());
-        compoundActivityDefinitionsApi.updateCompoundActivityDefinition(compoundTaskId, defToUpdate).execute();
+        forDevelopersApi.updateCompoundActivityDefinition(compoundTaskId, defToUpdate).execute();
 
         // Get scheduled activities again. Now we should get the updated compound activity.
         {

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SharedModuleMetadataTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SharedModuleMetadataTest.java
@@ -29,8 +29,8 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
+import org.sagebionetworks.bridge.rest.api.ForDevelopersApi;
 import org.sagebionetworks.bridge.rest.api.ForSuperadminsApi;
-import org.sagebionetworks.bridge.rest.api.SharedModulesApi;
 import org.sagebionetworks.bridge.rest.api.SurveysApi;
 import org.sagebionetworks.bridge.rest.api.UploadSchemasApi;
 import org.sagebionetworks.bridge.rest.exceptions.BadRequestException;
@@ -60,9 +60,9 @@ public class SharedModuleMetadataTest {
     // Note that this is canonically a set. However, Swagger only supports a list, so some wonkiness happens.
     private static final Set<String> TAGS = ImmutableSet.of("foo", "bar", "baz");
 
-    private static SharedModulesApi apiDeveloperModulesApi;
-    private static SharedModulesApi sharedDeveloperModulesApi;
-    private static SharedModulesApi nonAuthSharedModulesApi;
+    private static ForDevelopersApi apiDeveloperModulesApi;
+    private static ForDevelopersApi sharedDeveloperModulesApi;
+    private static ForDevelopersApi nonAuthSharedModulesApi;
     private static UploadSchemasApi devUploadSchemasApi;
     private static SurveysApi devSurveysApi;
     private static ForSuperadminsApi superadminsApi;
@@ -81,11 +81,11 @@ public class SharedModuleMetadataTest {
     public static void beforeClass() throws Exception {
         TestUserHelper.TestUser admin = TestUserHelper.getSignedInAdmin();
         apiDeveloper = TestUserHelper.createAndSignInUser(SharedModuleMetadataTest.class, false, DEVELOPER);
-        apiDeveloperModulesApi = apiDeveloper.getClient(SharedModulesApi.class);
+        apiDeveloperModulesApi = apiDeveloper.getClient(ForDevelopersApi.class);
         sharedDeveloper = TestUserHelper.createAndSignInUser(SharedModuleMetadataTest.class, SHARED_APP_ID, DEVELOPER);
-        sharedDeveloperModulesApi = sharedDeveloper.getClient(SharedModulesApi.class);
+        sharedDeveloperModulesApi = sharedDeveloper.getClient(ForDevelopersApi.class);
         nonAuthSharedModulesApi = Tests.getUnauthenticatedClientProvider(admin.getClientManager(), TEST_APP_ID)
-                .getClient(SharedModulesApi.class);
+                .getClient(ForDevelopersApi.class);
         devUploadSchemasApi = sharedDeveloper.getClient(UploadSchemasApi.class);
         devSurveysApi = sharedDeveloper.getClient(SurveysApi.class);
         adminsApi = admin.getClient(ForAdminsApi.class);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SharedModuleTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SharedModuleTest.java
@@ -18,8 +18,8 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
+import org.sagebionetworks.bridge.rest.api.ForDevelopersApi;
 import org.sagebionetworks.bridge.rest.api.ForSuperadminsApi;
-import org.sagebionetworks.bridge.rest.api.SharedModulesApi;
 import org.sagebionetworks.bridge.rest.api.SurveysApi;
 import org.sagebionetworks.bridge.rest.api.UploadSchemasApi;
 import org.sagebionetworks.bridge.rest.exceptions.BadRequestException;
@@ -143,7 +143,7 @@ public class SharedModuleTest {
         module = createModuleForSchema(sharedSchema);
 
         // Copy to local app.
-        SharedModuleImportStatus importStatus = apiDeveloper.getClient(SharedModulesApi.class)
+        SharedModuleImportStatus importStatus = apiDeveloper.getClient(ForDevelopersApi.class)
                 .importModuleByIdAndVersion(module.getId(), module.getVersion()).execute().body();
 
         // Get local schema and verify some fields.
@@ -163,7 +163,7 @@ public class SharedModuleTest {
         module = createModuleForSurvey(sharedSurvey);
 
         // Copy to local app.
-        SharedModuleImportStatus importStatus = apiDeveloper.getClient(SharedModulesApi.class)
+        SharedModuleImportStatus importStatus = apiDeveloper.getClient(ForDevelopersApi.class)
                 .importModuleByIdAndVersion(module.getId(), module.getVersion()).execute().body();
 
         // Get local survey and verify some fields.
@@ -182,7 +182,7 @@ public class SharedModuleTest {
         module = createModuleForSchema(sharedSchema);
 
         // Copy to local app.
-        SharedModuleImportStatus importStatus = apiDeveloper.getClient(SharedModulesApi.class)
+        SharedModuleImportStatus importStatus = apiDeveloper.getClient(ForDevelopersApi.class)
                 .importModuleByIdLatestPublishedVersion(module.getId()).execute().body();
 
         // Get local schema and verify some fields.
@@ -209,7 +209,7 @@ public class SharedModuleTest {
         String moduleId = "test-module-" + RandomStringUtils.randomAlphabetic(4);
         SharedModuleMetadata moduleToCreate = new SharedModuleMetadata().id(moduleId).name("Test Module With Schema")
                 .published(true).schemaId(schema.getSchemaId()).schemaRevision(schema.getRevision().intValue());
-        return sharedDeveloper.getClient(SharedModulesApi.class).createMetadata(moduleToCreate).execute().body();
+        return sharedDeveloper.getClient(ForDevelopersApi.class).createMetadata(moduleToCreate).execute().body();
     }
 
     // Helper method to verify shared schema and local schema match. Because the schemas are in different studies, they
@@ -250,7 +250,7 @@ public class SharedModuleTest {
         String moduleId = "test-module-" + RandomStringUtils.randomAlphabetic(4);
         SharedModuleMetadata moduleToCreate = new SharedModuleMetadata().id(moduleId).name("Test Module With Survey")
                 .published(true).surveyGuid(survey.getGuid()).surveyCreatedOn(survey.getCreatedOn().toString());
-        return sharedDeveloper.getClient(SharedModulesApi.class).createMetadata(moduleToCreate).execute().body();
+        return sharedDeveloper.getClient(ForDevelopersApi.class).createMetadata(moduleToCreate).execute().body();
     }
 
     // Helper method to verify shared survey and local survey match. Similar to assertLocalSchema().

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyTest.java
@@ -40,9 +40,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.rest.RestUtils;
-import org.sagebionetworks.bridge.rest.api.FilesApi;
 import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
+import org.sagebionetworks.bridge.rest.api.HostedFilesApi;
 import org.sagebionetworks.bridge.rest.api.OrganizationsApi;
 import org.sagebionetworks.bridge.rest.api.ParticipantsApi;
 import org.sagebionetworks.bridge.rest.api.StudiesApi;
@@ -236,7 +236,7 @@ public class StudyTest {
         
         // Now use the admin to delete the logo it via the files API (cleanup)
         String logoGuid = url.substring(url.lastIndexOf("/")+1, url.lastIndexOf("."));
-        admin.getClient(FilesApi.class).deleteFile(logoGuid, true).execute();
+        admin.getClient(HostedFilesApi.class).deleteFile(logoGuid, true).execute();
         
         // logically delete it
         studiesApi.deleteStudy(id, false).execute();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
@@ -83,10 +83,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
+import org.sagebionetworks.bridge.rest.api.ForDevelopersApi;
 import org.sagebionetworks.bridge.rest.api.ForSuperadminsApi;
 import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
 import org.sagebionetworks.bridge.rest.api.SchedulesV1Api;
-import org.sagebionetworks.bridge.rest.api.SharedModulesApi;
 import org.sagebionetworks.bridge.rest.api.SurveysApi;
 import org.sagebionetworks.bridge.rest.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.rest.exceptions.ConstraintViolationException;
@@ -149,7 +149,7 @@ public class SurveyTest {
     private static TestUser user;
     private static TestUser worker;
     private static TestUser sharedDeveloper;
-    private static SharedModulesApi sharedDeveloperModulesApi;
+    private static ForDevelopersApi sharedDeveloperModulesApi;
     private static SurveysApi sharedSurveysApi;
     private static ForAdminsApi adminsApi;
     private static ForSuperadminsApi superadminsApi;
@@ -170,7 +170,7 @@ public class SurveyTest {
         worker = TestUserHelper.createAndSignInUser(SurveyTest.class, false, Role.WORKER);
 
         sharedDeveloper = TestUserHelper.createAndSignInUser(SurveyTest.class, SHARED_APP_ID, DEVELOPER);        
-        sharedDeveloperModulesApi = sharedDeveloper.getClient(SharedModulesApi.class);
+        sharedDeveloperModulesApi = sharedDeveloper.getClient(ForDevelopersApi.class);
         sharedSurveysApi = sharedDeveloper.getClient(SurveysApi.class);
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
@@ -33,9 +33,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
+import org.sagebionetworks.bridge.rest.api.ForDevelopersApi;
 import org.sagebionetworks.bridge.rest.api.ForSuperadminsApi;
 import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
-import org.sagebionetworks.bridge.rest.api.SharedModulesApi;
 import org.sagebionetworks.bridge.rest.api.UploadSchemasApi;
 import org.sagebionetworks.bridge.rest.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.rest.exceptions.ConcurrentModificationException;
@@ -63,7 +63,7 @@ public class UploadSchemaTest {
     private static ForSuperadminsApi superadminApi;
     private static UploadSchemasApi devUploadSchemasApi;
     private static ForWorkersApi workerUploadSchemasApi;
-    private static SharedModulesApi sharedDeveloperModulesApi;
+    private static ForDevelopersApi sharedDeveloperModulesApi;
     private static UploadSchemasApi sharedUploadSchemasApi;
 
     private String schemaId;
@@ -75,7 +75,7 @@ public class UploadSchemaTest {
         user = TestUserHelper.createAndSignInUser(UploadSchemaTest.class, true);
         worker = TestUserHelper.createAndSignInUser(UploadSchemaTest.class, false, WORKER);
         sharedDeveloper = TestUserHelper.createAndSignInUser(UploadSchemaTest.class, SHARED_APP_ID, DEVELOPER);
-        sharedDeveloperModulesApi = sharedDeveloper.getClient(SharedModulesApi.class);
+        sharedDeveloperModulesApi = sharedDeveloper.getClient(ForDevelopersApi.class);
 
         adminApi = admin.getClient(ForAdminsApi.class);
         superadminApi = admin.getClient(ForSuperadminsApi.class);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserDataDownloadTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserDataDownloadTest.java
@@ -8,7 +8,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import retrofit2.Response;
 
-import org.sagebionetworks.bridge.rest.api.UsersApi;
+import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
 import org.sagebionetworks.bridge.rest.model.DateRange;
 import org.sagebionetworks.bridge.rest.model.Message;
 import org.sagebionetworks.bridge.user.TestUserHelper;
@@ -34,7 +34,7 @@ public class UserDataDownloadTest {
     public void withBody() throws Exception {
         LocalDate todaysDate = LocalDate.now();
         DateRange dateRange = new DateRange().startDate(todaysDate).endDate(todaysDate);
-        Response<Message> response = user.getClient(UsersApi.class).sendDataToUser(dateRange).execute();
+        Response<Message> response = user.getClient(ForConsentedUsersApi.class).sendDataToUser(dateRange).execute();
         assertEquals(202, response.code());
     }
 }


### PR DESCRIPTION
I've removed the model/category APIs for some APIs that we've never used, and deprecated those endpoints, but kept them on the role-based API classes so we can continue to access them and continue to test them. Switching over to those (otherwise, tests stay exactly the same...it's the same server call).