### PR TITLE
add dummy config values

### DIFF
--- a/src/test/resources/bridge-sdk-test.properties
+++ b/src/test/resources/bridge-sdk-test.properties
@@ -5,5 +5,9 @@ prod.synapse.endpoint = https://repo-prod.prod.sagebase.org/
 exporter.synapse.user.id = 3325672
 test.synapse.user.id = 0
 
+synapse.test.user.id = test-synapse-user-id
+synapse.test.user = test-synapse-user-name
+synapse.test.user.password = test-synapse-password
+
 synapse.oauth.client.id = 100001
 prod.synapse.oauth.client.id = 100018


### PR DESCRIPTION
Fix for https://sagebionetworks.jira.com/browse/BRIDGE-2803

Dummy config values needed to be specified in bridge-sdk-test.properties so that Jenkins can override them with environment variables.