### PR TITLE
Make OAuthTest a Smoke Test

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthTest.java
@@ -28,6 +28,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import org.sagebionetworks.bridge.config.Config;
 import org.sagebionetworks.bridge.rest.RestUtils;
@@ -49,6 +50,7 @@ import org.sagebionetworks.bridge.rest.model.VersionHolder;
 import org.sagebionetworks.bridge.user.TestUserHelper;
 import org.sagebionetworks.bridge.user.TestUserHelper.TestUser;
 
+@Category(IntegrationSmokeTest.class)
 public class OAuthTest {
     private static final String SYNAPSE_LOGIN_URL = "auth/v1/login";
     private static final String SYNAPSE_OAUTH_CONSENT = "auth/v1/oauth2/consent";


### PR DESCRIPTION
OAuth seems important enough that we should test this in Prod.

In addition, this helps ensure that our Prod server and Integ Tests talk to Synapse Prod correctly.