### PR TITLE
Fix ParticipantVersionTest

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantVersionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ParticipantVersionTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.sagebionetworks.bridge.sdk.integration.Tests.DEFAULT_STUDY_ID;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.PASSWORD;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.STUDY_ID_1;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_ID;
@@ -32,7 +31,6 @@ import org.sagebionetworks.bridge.rest.api.ParticipantsApi;
 import org.sagebionetworks.bridge.rest.api.StudyParticipantsApi;
 import org.sagebionetworks.bridge.rest.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.rest.model.ConsentSignature;
-import org.sagebionetworks.bridge.rest.model.Enrollment;
 import org.sagebionetworks.bridge.rest.model.ParticipantVersion;
 import org.sagebionetworks.bridge.rest.model.Role;
 import org.sagebionetworks.bridge.rest.model.SharingScope;
@@ -77,8 +75,8 @@ public class ParticipantVersionTest {
         AuthenticationApi authApi = unauthenticatedProvider.getAuthenticationApi();
 
         // Create user via sign up. Use external ID so we can bypass email verification.
-        SignUp signUp = new SignUp().appId(TEST_APP_ID).addDataGroupsItem("test_user").externalId(extId)
-                .password(PASSWORD);
+        SignUp signUp = new SignUp().appId(TEST_APP_ID).addDataGroupsItem("test_user")
+                .putExternalIdsItem(STUDY_ID_1, extId).password(PASSWORD);
         authApi.signUp(signUp).execute();
 
         // Sign in. This throws because we're not consented yet.
@@ -113,12 +111,9 @@ public class ParticipantVersionTest {
         assertEquals(SharingScope.SPONSORS_AND_PARTNERS, participantVersion1.getSharingScope());
         assertNull(participantVersion1.getTimeZone());
 
-        // TEST_APP_ID->extId is created when we create the user with an external ID.
-        // STUDY_ID_1->"<none>" is created when we consent.
         Map<String, String> studyMembershipMap = participantVersion1.getStudyMemberships();
-        assertEquals(2, studyMembershipMap.size());
-        assertEquals(extId, studyMembershipMap.get(DEFAULT_STUDY_ID));
-        assertEquals("<none>", studyMembershipMap.get(STUDY_ID_1));
+        assertEquals(1, studyMembershipMap.size());
+        assertEquals(extId, studyMembershipMap.get(STUDY_ID_1));
 
         // Update participant by updating time zone.
         ParticipantsApi participantsApi = admin.getClient(ParticipantsApi.class);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
@@ -67,7 +67,6 @@ public class Tests {
     public static final String FINGERPRINT = "14:6D:E9:83:C5:73:06:50:D8:EE:B9:95:2F:34:FC:64:16:A0:83:42:E6:1D:BE:A8:8A:04:96:B2:3F:CF:44:E5";
     public static final String APP_NAME = "Integration Tests";
     public static final String PASSWORD = "P@ssword`1";
-    public static final String DEFAULT_STUDY_ID = TEST_APP_ID + "-study";
     public static final String STUDY_ID_1 = "study1";
     public static final String STUDY_ID_2 = "study2";
     public static final String ORG_ID_1 = "org1";


### PR DESCRIPTION
My local app had the default study api-study, but dev does not. This resulted in a test that passes locally, but not in dev.

I fixed it by assigning an external ID directly to the study1 study instead of relying on the default study (which is non-deterministic anyway). Tested this in both local and dev.