### PR TITLE
BRIDGE-3152 (integration tests in production)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # BridgeIntegrationTests
-Integration Tests for Bridge server
+
+Integration tests for the BridgeServer2 server. Integration tests require a bootstrap account on the server to execute. Outside of production, the full suite of tests runs using  `SUPERADMIN` account. On production, for security reasons, a subset of these tests execute using an `ADMIN` account. (The `ADMIN` account can’t access all apps, or create worker accounts that can access all apps.)
+
+The production tests are marked with the `@Category(IntegrationSmokeTest.class)` class annotation.
+
+## Setting up your environment to run integration tests
+
+The integration tests use the Bridge Java REST SDK, and both the SDK and the tests need some properties to be set in order to run (in the following property files):
+
+**~/bridge-sdk.properties**
+
+    log.level = warn
+    env = local
+    languages = en
+
+**~/bridge-sdk-test.properties**
+
+    dev.name = alxdark
+
+    admin.email = <email address>
+    admin.password = <password>
+
+    synapse.test.user = <user name>
+    synapse.test.user.id = <numerical account ID>
+    synapse.test.user.password = <password>
+    synapse.test.user.api.key = <api key>
+
+**admin.email** and **admin.password:** Create an account with the `SUPERADMIN` role outside of production and the `ADMIN` role in production. This account should be created in the 'api' and 'shared' apps, with the same email and password, and the same synapse user ID of 0000 (four zeroes) in both apps (this allows an `ADMIN` account to to switch between these two studies). These are test apps, so accidents in these apps would not impact other production apps.
+
+The **synapse.test.*** keys are available in LastPass.
+
+It should be possible to start the server and run `mvn clean test` at this point.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The integration tests use the Bridge Java REST SDK, and both the SDK and the tes
 
 **~/bridge-sdk-test.properties**
 
-    dev.name = alxdark
+    dev.name = <dev name>
 
     admin.email = <email address>
     admin.password = <password>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>BridgeIntegTestUtils</artifactId>
-            <version>1.2.5</version>
+            <version>1.2.6</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.23.8</version>
+            <version>0.23.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.23.9</version>
+            <version>0.23.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AppTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AppTest.java
@@ -47,6 +47,7 @@ import retrofit2.Response;
 import org.sagebionetworks.bridge.config.PropertiesConfig;
 import org.sagebionetworks.bridge.rest.ClientManager;
 import org.sagebionetworks.bridge.rest.api.AppsApi;
+import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
 import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
 import org.sagebionetworks.bridge.rest.api.ForSuperadminsApi;
 import org.sagebionetworks.bridge.rest.api.UploadsApi;
@@ -84,7 +85,7 @@ public class AppTest {
     private Team team;
 
     private static final String EXPORTER_SYNAPSE_USER_ID_NAME = "exporter.synapse.user.id";
-    private static final String TEST_USER_ID_NAME = "test.synapse.user.id";
+    private static final String TEST_USER_ID_NAME = "synapse.test.user.id";
 
     // synapse related attributes
     private static String EXPORTER_SYNAPSE_USER_ID;
@@ -215,6 +216,7 @@ public class AppTest {
     @Test
     public void crudApp() throws Exception {
         ForSuperadminsApi superadminApi = admin.getClient(ForSuperadminsApi.class);
+        AuthenticationApi authApi = admin.getClient(AuthenticationApi.class);
 
         appId = Tests.randomIdentifier(getClass());
         App app = Tests.getApp(appId, null);
@@ -231,7 +233,7 @@ public class AppTest {
         VersionHolder holder = superadminApi.createApp(app).execute().body();
         assertNotNull(holder.getVersion());
 
-        superadminApi.adminChangeApp(new SignIn().appId(appId)).execute();
+        authApi.changeApp(new SignIn().appId(appId)).execute();
         App newApp = superadminApi.getApp(app.getIdentifier()).execute().body();
         
         app.addDataGroupsItem("test_user"); // added by the server, required for equality of dataGroups.
@@ -340,7 +342,7 @@ public class AppTest {
         
         // and then you have to switch back, because after you delete this test app, 
         // all users signed into that app are locked out of working.
-        superadminApi.adminChangeApp(new SignIn().appId(TEST_APP_ID)).execute();
+        authApi.changeApp(new SignIn().appId(TEST_APP_ID)).execute();
 
         // logically delete a app by admin
         superadminApi.deleteApp(appId, false).execute();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AssessmentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AssessmentTest.java
@@ -32,8 +32,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.rest.api.AssessmentsApi;
+import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
 import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
-import org.sagebionetworks.bridge.rest.api.ForSuperadminsApi;
 import org.sagebionetworks.bridge.rest.api.OrganizationsApi;
 import org.sagebionetworks.bridge.rest.api.SharedAssessmentsApi;
 import org.sagebionetworks.bridge.rest.api.TagsApi;
@@ -344,7 +344,7 @@ public class AssessmentTest {
         }
         
         TestUser admin = TestUserHelper.getSignedInAdmin();
-        ForSuperadminsApi superAdminApi = admin.getClient(ForSuperadminsApi.class);
+        AuthenticationApi authApi = admin.getClient(AuthenticationApi.class);
         SharedAssessmentsApi adminSharedApi = admin.getClient(SharedAssessmentsApi.class);
 
         // Import a shared assessment back into the app
@@ -373,7 +373,7 @@ public class AssessmentTest {
             adminAssessmentsApi.deleteAssessment(revision.getGuid(), true).execute();
         }
         try {
-            superAdminApi.adminChangeApp(SHARED_SIGNIN).execute();
+            authApi.changeApp(SHARED_SIGNIN).execute();
             // test logical delete of shared assessments
             adminSharedApi.deleteSharedAssessment(shared.getGuid(), false).execute().body();
             
@@ -387,7 +387,7 @@ public class AssessmentTest {
             
             adminSharedApi.deleteSharedAssessment(shared.getGuid(), true).execute().body();
         } finally {
-            superAdminApi.adminChangeApp(API_SIGNIN).execute();
+            authApi.changeApp(API_SIGNIN).execute();
         }
         // Should all be gone...
         list = sharedApi.getSharedAssessments(null, null, ImmutableList.of(markerTag), true).execute().body();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthorizationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthorizationTest.java
@@ -16,6 +16,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.sagebionetworks.bridge.rest.api.ForOrgAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ParticipantsApi;
 import org.sagebionetworks.bridge.rest.api.StudiesApi;
@@ -31,6 +32,7 @@ import org.sagebionetworks.bridge.user.TestUserHelper.TestUser;
 
 import retrofit2.Call;
 
+@Category(IntegrationSmokeTest.class)
 public class AuthorizationTest {
 
     private static TestUser developer;

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ConsentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ConsentTest.java
@@ -44,7 +44,6 @@ import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
 import org.sagebionetworks.bridge.rest.api.ForDevelopersApi;
 import org.sagebionetworks.bridge.rest.api.ForResearchersApi;
-import org.sagebionetworks.bridge.rest.api.ForSuperadminsApi;
 import org.sagebionetworks.bridge.rest.api.InternalApi;
 import org.sagebionetworks.bridge.rest.api.ParticipantsApi;
 import org.sagebionetworks.bridge.rest.api.SchedulesV2Api;
@@ -123,10 +122,10 @@ public class ConsentTest {
                 .withSignUp(phoneOnlyUser).createAndSignInUser();
 
         // Verify necessary flags (health code export) are enabled
-        ForSuperadminsApi adminApi = adminUser.getClient(ForSuperadminsApi.class);
-        App app = adminApi.getApp(TEST_APP_ID).execute().body();
+        ForAdminsApi adminApi = adminUser.getClient(ForAdminsApi.class);
+        App app = adminApi.getUsersApp().execute().body();
         app.setHealthCodeExportEnabled(true);
-        adminApi.updateApp(app.getIdentifier(), app).execute();
+        adminApi.updateUsersApp(app).execute();
     }
 
     @AfterClass

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/InitListener.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/InitListener.java
@@ -151,19 +151,18 @@ public class InitListener extends RunListener {
             admin.getClient(ForOrgAdminsApi.class).addMember(SAGE_ID, admin.getUserId()).execute();
         }
         
-        admin.getClient(ForSuperadminsApi.class).adminChangeApp(new SignIn().appId(SHARED_APP_ID)).execute();
-        
-        try {
-            orgsApi.getOrganization(SAGE_ID).execute();
-        } catch(EntityNotFoundException e) {
-            Organization org = new Organization().identifier(SAGE_ID).name(SAGE_NAME)
-                    .description("Sage sponsors study1 and study2");
-            orgsApi.createOrganization(org).execute();
-            LOG.info("  Creating organization “{}” in shared study", SAGE_ID);
-        } finally {
-            admin.getClient(ForSuperadminsApi.class).adminChangeApp(new SignIn().appId(TEST_APP_ID)).execute();
-        }
-        
+//        admin.getClient(ForSuperadminsApi.class).adminChangeApp(new SignIn().appId(SHARED_APP_ID)).execute();
+//        
+//        try {
+//            orgsApi.getOrganization(SAGE_ID).execute();
+//        } catch(EntityNotFoundException e) {
+//            Organization org = new Organization().identifier(SAGE_ID).name(SAGE_NAME)
+//                    .description("Sage sponsors study1 and study2");
+//            orgsApi.createOrganization(org).execute();
+//            LOG.info("  Creating organization “{}” in shared study", SAGE_ID);
+//        } finally {
+//            admin.getClient(ForSuperadminsApi.class).adminChangeApp(new SignIn().appId(TEST_APP_ID)).execute();
+//        }
 
         testRunInitialized = true;
     }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/InitListener.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/InitListener.java
@@ -3,8 +3,10 @@ package org.sagebionetworks.bridge.sdk.integration;
 import static org.sagebionetworks.bridge.rest.model.ActivityEventUpdateType.FUTURE_ONLY;
 import static org.sagebionetworks.bridge.rest.model.ActivityEventUpdateType.IMMUTABLE;
 import static org.sagebionetworks.bridge.rest.model.ActivityEventUpdateType.MUTABLE;
+import static org.sagebionetworks.bridge.sdk.integration.Tests.API_SIGNIN;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.ORG_ID_1;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.ORG_ID_2;
+import static org.sagebionetworks.bridge.sdk.integration.Tests.SHARED_SIGNIN;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.STUDY_ID_1;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.STUDY_ID_2;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.SAGE_ID;
@@ -20,7 +22,7 @@ import org.junit.runner.Result;
 import org.junit.runner.notification.RunListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
 import org.sagebionetworks.bridge.rest.api.ForOrgAdminsApi;
 import org.sagebionetworks.bridge.rest.api.OrganizationsApi;
 import org.sagebionetworks.bridge.rest.api.StudiesApi;
@@ -148,18 +150,18 @@ public class InitListener extends RunListener {
             admin.getClient(ForOrgAdminsApi.class).addMember(SAGE_ID, admin.getUserId()).execute();
         }
         
-//        admin.getClient(ForSuperadminsApi.class).adminChangeApp(new SignIn().appId(SHARED_APP_ID)).execute();
-//        
-//        try {
-//            orgsApi.getOrganization(SAGE_ID).execute();
-//        } catch(EntityNotFoundException e) {
-//            Organization org = new Organization().identifier(SAGE_ID).name(SAGE_NAME)
-//                    .description("Sage sponsors study1 and study2");
-//            orgsApi.createOrganization(org).execute();
-//            LOG.info("  Creating organization “{}” in shared study", SAGE_ID);
-//        } finally {
-//            admin.getClient(ForSuperadminsApi.class).adminChangeApp(new SignIn().appId(TEST_APP_ID)).execute();
-//        }
+        admin.getClient(AuthenticationApi.class).changeApp(SHARED_SIGNIN).execute();
+        
+        try {
+            orgsApi.getOrganization(SAGE_ID).execute();
+        } catch(EntityNotFoundException e) {
+            Organization org = new Organization().identifier(SAGE_ID).name(SAGE_NAME)
+                    .description("Sage sponsors study1 and study2");
+            orgsApi.createOrganization(org).execute();
+            LOG.info("  Creating organization “{}” in shared study", SAGE_ID);
+        } finally {
+            admin.getClient(AuthenticationApi.class).changeApp(API_SIGNIN).execute();
+        }
 
         testRunInitialized = true;
     }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/InitListener.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/InitListener.java
@@ -9,7 +9,6 @@ import static org.sagebionetworks.bridge.sdk.integration.Tests.STUDY_ID_1;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.STUDY_ID_2;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.SAGE_ID;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.SAGE_NAME;
-import static org.sagebionetworks.bridge.util.IntegTestUtils.SHARED_APP_ID;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_ID;
 
 import java.util.ArrayList;
@@ -23,7 +22,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.sagebionetworks.bridge.rest.api.ForOrgAdminsApi;
-import org.sagebionetworks.bridge.rest.api.ForSuperadminsApi;
 import org.sagebionetworks.bridge.rest.api.OrganizationsApi;
 import org.sagebionetworks.bridge.rest.api.StudiesApi;
 import org.sagebionetworks.bridge.rest.api.SubpopulationsApi;
@@ -31,7 +29,6 @@ import org.sagebionetworks.bridge.rest.exceptions.ConstraintViolationException;
 import org.sagebionetworks.bridge.rest.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.rest.model.CustomEvent;
 import org.sagebionetworks.bridge.rest.model.Organization;
-import org.sagebionetworks.bridge.rest.model.SignIn;
 import org.sagebionetworks.bridge.rest.model.Study;
 import org.sagebionetworks.bridge.rest.model.Subpopulation;
 import org.sagebionetworks.bridge.user.TestUserHelper;

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthForWorkerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthForWorkerTest.java
@@ -1,0 +1,88 @@
+package org.sagebionetworks.bridge.sdk.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.sagebionetworks.bridge.rest.model.Role.WORKER;
+import static org.sagebionetworks.bridge.util.IntegTestUtils.CONFIG;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.sagebionetworks.bridge.rest.api.ForSuperadminsApi;
+import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
+import org.sagebionetworks.bridge.rest.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.rest.model.App;
+import org.sagebionetworks.bridge.rest.model.ForwardCursorStringList;
+import org.sagebionetworks.bridge.rest.model.OAuthProvider;
+import org.sagebionetworks.bridge.rest.model.SignUp;
+import org.sagebionetworks.bridge.rest.model.VersionHolder;
+import org.sagebionetworks.bridge.user.TestUserHelper;
+import org.sagebionetworks.bridge.user.TestUserHelper.TestUser;
+
+import com.google.common.collect.ImmutableList;
+
+public class OAuthForWorkerTest {
+    
+    private TestUser admin;
+    private TestUser worker;
+
+    @Before
+    public void before() throws Exception {
+        admin = TestUserHelper.getSignedInAdmin();
+    }
+    
+    @After
+    public void after() throws Exception {
+        // Force admin back to the API test
+        admin.signOut();
+        if (worker != null) {
+            worker.signOutAndDeleteUser();
+        }
+    }
+
+    @Test
+    public void test() throws Exception {
+        String synapseUserId = CONFIG.get("synapse.test.user.id");
+        worker = TestUserHelper.createAndSignInUser(OAuthTest.class, true, 
+                new SignUp().roles(ImmutableList.of(WORKER)).synapseUserId(synapseUserId));
+        
+        ForWorkersApi workersApi = worker.getClient(ForWorkersApi.class);
+        
+        try {
+            workersApi.getHealthCodesGrantingOAuthAccess(worker.getAppId(), "unused-vendor-id", null, null).execute().body();
+            fail("Should have thrown exception.");
+        } catch(EntityNotFoundException e) {
+            assertEquals("OAuthProvider not found.", e.getMessage());
+        }
+        try {
+            workersApi.getOAuthAccessToken(worker.getAppId(), "unused-vendor-id", "ABC-DEF-GHI").execute().body();
+            fail("Should have thrown exception.");
+        } catch(EntityNotFoundException e) {
+            assertEquals("OAuthProvider not found.", e.getMessage());
+        }
+        ForSuperadminsApi superadminApi = admin.getClient(ForSuperadminsApi.class);
+        App app = superadminApi.getApp(worker.getAppId()).execute().body();
+        try {
+            OAuthProvider provider = new OAuthProvider().clientId("foo").endpoint("https://webservices.sagebridge.org/")
+                    .callbackUrl("https://webservices.sagebridge.org/").secret("secret");
+            
+            app.getOAuthProviders().put("bridge", provider);
+            VersionHolder version = superadminApi.updateApp(app.getIdentifier(), app).execute().body();
+            app.setVersion(version.getVersion()); 
+            
+            ForwardCursorStringList list = workersApi.getHealthCodesGrantingOAuthAccess(worker.getAppId(), "bridge", null, null).execute().body();
+            assertTrue(list.getItems().isEmpty());
+            try {
+                workersApi.getOAuthAccessToken(worker.getAppId(), "bridge", "ABC-DEF-GHI").execute();
+                fail("Should have thrown an exception");
+            } catch(EntityNotFoundException e) {
+                
+            }
+        } finally {
+            app.getOAuthProviders().remove("bridge");
+            superadminApi.updateApp(app.getIdentifier(), app).execute();
+        }
+    }
+
+}

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthTest.java
@@ -10,6 +10,7 @@ import static org.sagebionetworks.bridge.rest.model.Role.WORKER;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.API_SIGNIN;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.SHARED_SIGNIN;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.escapeJSON;
+import static org.sagebionetworks.bridge.util.IntegTestUtils.CONFIG;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.SHARED_APP_ID;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_ID;
 
@@ -31,7 +32,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.sagebionetworks.bridge.config.Config;
-import org.sagebionetworks.bridge.config.Environment;
 import org.sagebionetworks.bridge.rest.RestUtils;
 import org.sagebionetworks.bridge.rest.api.AppsApi;
 import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
@@ -41,6 +41,7 @@ import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
 import org.sagebionetworks.bridge.rest.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.rest.model.App;
 import org.sagebionetworks.bridge.rest.model.AppList;
+import org.sagebionetworks.bridge.rest.model.Environment;
 import org.sagebionetworks.bridge.rest.model.ForwardCursorStringList;
 import org.sagebionetworks.bridge.rest.model.OAuthAuthorizationToken;
 import org.sagebionetworks.bridge.rest.model.OAuthProvider;
@@ -50,23 +51,17 @@ import org.sagebionetworks.bridge.rest.model.UserSessionInfo;
 import org.sagebionetworks.bridge.rest.model.VersionHolder;
 import org.sagebionetworks.bridge.user.TestUserHelper;
 import org.sagebionetworks.bridge.user.TestUserHelper.TestUser;
+import org.sagebionetworks.bridge.util.IntegTestUtils;
 
 @Category(IntegrationSmokeTest.class)
 public class OAuthTest {
     private static final String SYNAPSE_LOGIN_URL = "auth/v1/login";
     private static final String SYNAPSE_OAUTH_CONSENT = "auth/v1/oauth2/consent";
 
-    private static Config config;
-
     private TestUser admin;
     private TestUser user;
     private TestUser user2;
     private TestUser worker;
-
-    @BeforeClass
-    public static void beforeClass() throws Exception {
-        config = Tests.loadTestConfig();
-    }
 
     @Before
     public void before() throws Exception {
@@ -100,7 +95,7 @@ public class OAuthTest {
     
     @Test
     public void test() throws Exception {
-        String synapseUserId = config.get("synapse.test.user.id");
+        String synapseUserId = CONFIG.get("synapse.test.user.id");
         worker = TestUserHelper.createAndSignInUser(OAuthTest.class, true, 
                 new SignUp().roles(ImmutableList.of(WORKER)).synapseUserId(synapseUserId));
         
@@ -144,11 +139,11 @@ public class OAuthTest {
     
     @Test
     public void signInWithSynapseAccount() throws Exception {
-        String oauthClientId = config.get("synapse.oauth.client.id");
-        String userEmail = config.get("synapse.test.user");
-        String userPassword = config.get("synapse.test.user.password");
-        String synapseEndpoint = config.get("synapse.endpoint");
-        String synapseUserId = config.get("synapse.test.user.id");
+        String oauthClientId = CONFIG.get("synapse.oauth.client.id");
+        String userEmail = CONFIG.get("synapse.test.user");
+        String userPassword = CONFIG.get("synapse.test.user.password");
+        String synapseEndpoint = CONFIG.get("synapse.endpoint");
+        String synapseUserId = CONFIG.get("synapse.test.user.id");
 
         worker = TestUserHelper.createAndSignInUser(OAuthTest.class, true,
                 new SignUp().roles(ImmutableList.of(WORKER)).synapseUserId(synapseUserId));
@@ -189,19 +184,19 @@ public class OAuthTest {
     
     @Test
     public void signInWithSynapseAccountUsingRestUtils() throws Exception {
-        String synapseUserId = config.get("synapse.test.user.id");
+        String synapseUserId = CONFIG.get("synapse.test.user.id");
         worker = TestUserHelper.createAndSignInUser(OAuthTest.class, true,
                 new SignUp().roles(ImmutableList.of(WORKER)).synapseUserId(synapseUserId));
         
-        String userEmail = config.get("synapse.test.user");
-        String userPassword = config.get("synapse.test.user.password");
+        String userEmail = CONFIG.get("synapse.test.user");
+        String userPassword = CONFIG.get("synapse.test.user.password");
         worker.signOut();
 
         SignIn signIn = new SignIn().appId(TEST_APP_ID).email(userEmail).password(userPassword);
         AuthenticationApi authApi = worker.getClient(AuthenticationApi.class);
         
         UserSessionInfo session;
-        if (config.getEnvironment() == Environment.PROD) {
+        if (CONFIG.getEnvironment() == Environment.PRODUCTION) {
             session = RestUtils.signInWithSynapse(authApi, signIn);
         } else {
             session = RestUtils.signInWithSynapseDev(authApi, signIn);
@@ -214,7 +209,7 @@ public class OAuthTest {
     @Test
     public void synapseUserCanSwitchBetweenStudies() throws Exception {
         // Going to use the shared app as well as the API app for this test.
-        String synapseUserId = config.get("synapse.test.user.id");
+        String synapseUserId = CONFIG.get("synapse.test.user.id");
         
         user = new TestUserHelper.Builder(OAuthTest.class).withAppId(TEST_APP_ID)
                 .withSignUp(new SignUp().appId(TEST_APP_ID)

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthTest.java
@@ -3,10 +3,7 @@ package org.sagebionetworks.bridge.sdk.integration;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.sagebionetworks.bridge.rest.model.Role.DEVELOPER;
-import static org.sagebionetworks.bridge.rest.model.Role.WORKER;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.API_SIGNIN;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.SHARED_SIGNIN;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.escapeJSON;
@@ -27,31 +24,22 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.sagebionetworks.bridge.config.Config;
 import org.sagebionetworks.bridge.rest.RestUtils;
 import org.sagebionetworks.bridge.rest.api.AppsApi;
 import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
 import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
-import org.sagebionetworks.bridge.rest.api.ForSuperadminsApi;
-import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
 import org.sagebionetworks.bridge.rest.exceptions.EntityNotFoundException;
-import org.sagebionetworks.bridge.rest.model.App;
 import org.sagebionetworks.bridge.rest.model.AppList;
 import org.sagebionetworks.bridge.rest.model.Environment;
-import org.sagebionetworks.bridge.rest.model.ForwardCursorStringList;
 import org.sagebionetworks.bridge.rest.model.OAuthAuthorizationToken;
-import org.sagebionetworks.bridge.rest.model.OAuthProvider;
 import org.sagebionetworks.bridge.rest.model.SignIn;
 import org.sagebionetworks.bridge.rest.model.SignUp;
 import org.sagebionetworks.bridge.rest.model.UserSessionInfo;
-import org.sagebionetworks.bridge.rest.model.VersionHolder;
 import org.sagebionetworks.bridge.user.TestUserHelper;
 import org.sagebionetworks.bridge.user.TestUserHelper.TestUser;
-import org.sagebionetworks.bridge.util.IntegTestUtils;
 
 @Category(IntegrationSmokeTest.class)
 public class OAuthTest {
@@ -61,7 +49,7 @@ public class OAuthTest {
     private TestUser admin;
     private TestUser user;
     private TestUser user2;
-    private TestUser worker;
+    private TestUser developer;
 
     @Before
     public void before() throws Exception {
@@ -75,8 +63,8 @@ public class OAuthTest {
         if (user != null) {
             user.signOutAndDeleteUser();
         }
-        if (worker != null) {
-            worker.signOutAndDeleteUser();
+        if (developer != null) {
+            developer.signOutAndDeleteUser();
         }
         if (user2 != null) {
             user2.signOutAndDeleteUser();
@@ -94,50 +82,6 @@ public class OAuthTest {
     }
     
     @Test
-    public void test() throws Exception {
-        String synapseUserId = CONFIG.get("synapse.test.user.id");
-        worker = TestUserHelper.createAndSignInUser(OAuthTest.class, true, 
-                new SignUp().roles(ImmutableList.of(WORKER)).synapseUserId(synapseUserId));
-        
-        ForWorkersApi workersApi = worker.getClient(ForWorkersApi.class);
-        
-        try {
-            workersApi.getHealthCodesGrantingOAuthAccess(worker.getAppId(), "unused-vendor-id", null, null).execute().body();
-            fail("Should have thrown exception.");
-        } catch(EntityNotFoundException e) {
-            assertEquals("OAuthProvider not found.", e.getMessage());
-        }
-        try {
-            workersApi.getOAuthAccessToken(worker.getAppId(), "unused-vendor-id", "ABC-DEF-GHI").execute().body();
-            fail("Should have thrown exception.");
-        } catch(EntityNotFoundException e) {
-            assertEquals("OAuthProvider not found.", e.getMessage());
-        }
-        ForSuperadminsApi superadminApi = admin.getClient(ForSuperadminsApi.class);
-        App app = superadminApi.getApp(worker.getAppId()).execute().body();
-        try {
-            OAuthProvider provider = new OAuthProvider().clientId("foo").endpoint("https://webservices.sagebridge.org/")
-                    .callbackUrl("https://webservices.sagebridge.org/").secret("secret");
-            
-            app.getOAuthProviders().put("bridge", provider);
-            VersionHolder version = superadminApi.updateApp(app.getIdentifier(), app).execute().body();
-            app.setVersion(version.getVersion()); 
-            
-            ForwardCursorStringList list = workersApi.getHealthCodesGrantingOAuthAccess(worker.getAppId(), "bridge", null, null).execute().body();
-            assertTrue(list.getItems().isEmpty());
-            try {
-                workersApi.getOAuthAccessToken(worker.getAppId(), "bridge", "ABC-DEF-GHI").execute();
-                fail("Should have thrown an exception");
-            } catch(EntityNotFoundException e) {
-                
-            }
-        } finally {
-            app.getOAuthProviders().remove("bridge");
-            superadminApi.updateApp(app.getIdentifier(), app).execute();
-        }
-    }
-    
-    @Test
     public void signInWithSynapseAccount() throws Exception {
         String oauthClientId = CONFIG.get("synapse.oauth.client.id");
         String userEmail = CONFIG.get("synapse.test.user");
@@ -145,9 +89,9 @@ public class OAuthTest {
         String synapseEndpoint = CONFIG.get("synapse.endpoint");
         String synapseUserId = CONFIG.get("synapse.test.user.id");
 
-        worker = TestUserHelper.createAndSignInUser(OAuthTest.class, true,
-                new SignUp().roles(ImmutableList.of(WORKER)).synapseUserId(synapseUserId));
-        worker.signOut();
+        developer = TestUserHelper.createAndSignInUser(OAuthTest.class, true,
+                new SignUp().roles(ImmutableList.of(DEVELOPER)).synapseUserId(synapseUserId));
+        developer.signOut();
 
         // Sign in to Synapse
         String payload = escapeJSON(format("{'username':'%s','password':'%s'}", userEmail, userPassword));
@@ -175,25 +119,25 @@ public class OAuthTest {
                 .authToken(authToken)
                 .callbackUrl("https://research.sagebridge.org");
         
-        AuthenticationApi authApi = worker.getClient(AuthenticationApi.class);
+        AuthenticationApi authApi = developer.getClient(AuthenticationApi.class);
         UserSessionInfo session = authApi.signInWithOauthToken(token).execute().body();
         
-        assertEquals(session.getId(), worker.getSession().getId());
-        assertEquals(session.getSynapseUserId(), worker.getSession().getSynapseUserId());
+        assertEquals(session.getId(), developer.getSession().getId());
+        assertEquals(session.getSynapseUserId(), developer.getSession().getSynapseUserId());
     }
     
     @Test
     public void signInWithSynapseAccountUsingRestUtils() throws Exception {
         String synapseUserId = CONFIG.get("synapse.test.user.id");
-        worker = TestUserHelper.createAndSignInUser(OAuthTest.class, true,
-                new SignUp().roles(ImmutableList.of(WORKER)).synapseUserId(synapseUserId));
+        developer = TestUserHelper.createAndSignInUser(OAuthTest.class, true,
+                new SignUp().roles(ImmutableList.of(DEVELOPER)).synapseUserId(synapseUserId));
         
         String userEmail = CONFIG.get("synapse.test.user");
         String userPassword = CONFIG.get("synapse.test.user.password");
-        worker.signOut();
+        developer.signOut();
 
         SignIn signIn = new SignIn().appId(TEST_APP_ID).email(userEmail).password(userPassword);
-        AuthenticationApi authApi = worker.getClient(AuthenticationApi.class);
+        AuthenticationApi authApi = developer.getClient(AuthenticationApi.class);
         
         UserSessionInfo session;
         if (CONFIG.getEnvironment() == Environment.PRODUCTION) {
@@ -202,8 +146,8 @@ public class OAuthTest {
             session = RestUtils.signInWithSynapseDev(authApi, signIn);
         }
         
-        assertEquals(session.getId(), worker.getSession().getId());
-        assertEquals(session.getSynapseUserId(), worker.getSession().getSynapseUserId());
+        assertEquals(session.getId(), developer.getSession().getId());
+        assertEquals(session.getSynapseUserId(), developer.getSession().getSynapseUserId());
     }
     
     @Test
@@ -217,7 +161,7 @@ public class OAuthTest {
                 .createAndSignInUser();
         String userId = user.getUserId();
 
-        admin.getClient(ForSuperadminsApi.class).adminChangeApp(SHARED_SIGNIN).execute();
+        admin.getClient(AuthenticationApi.class).changeApp(SHARED_SIGNIN).execute();
         
         user2 = new TestUserHelper.Builder(OAuthTest.class).withAppId(SHARED_APP_ID)
                 .withSignUp(new SignUp().appId(SHARED_APP_ID)
@@ -244,6 +188,8 @@ public class OAuthTest {
         // Verify this has an immediate effect on the other user
         list = user.getClient(AppsApi.class).getAppMemberships().execute().body();
         assertEquals(list.getItems().size(), 1);
+        
+        admin.getClient(AuthenticationApi.class).changeApp(API_SIGNIN).execute();
     }
     
     private String getValue(HttpResponse response, String property) throws Exception {

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SharedModuleMetadataTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SharedModuleMetadataTest.java
@@ -28,9 +28,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
 import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ForDevelopersApi;
-import org.sagebionetworks.bridge.rest.api.ForSuperadminsApi;
 import org.sagebionetworks.bridge.rest.api.SurveysApi;
 import org.sagebionetworks.bridge.rest.api.UploadSchemasApi;
 import org.sagebionetworks.bridge.rest.exceptions.BadRequestException;
@@ -65,7 +65,7 @@ public class SharedModuleMetadataTest {
     private static ForDevelopersApi nonAuthSharedModulesApi;
     private static UploadSchemasApi devUploadSchemasApi;
     private static SurveysApi devSurveysApi;
-    private static ForSuperadminsApi superadminsApi;
+    private static AuthenticationApi authApi;
     private static ForAdminsApi adminsApi;
     private static SurveysApi adminSurveysApi;
     
@@ -89,8 +89,8 @@ public class SharedModuleMetadataTest {
         devUploadSchemasApi = sharedDeveloper.getClient(UploadSchemasApi.class);
         devSurveysApi = sharedDeveloper.getClient(SurveysApi.class);
         adminsApi = admin.getClient(ForAdminsApi.class);
-        superadminsApi = admin.getClient(ForSuperadminsApi.class);
-        superadminsApi.adminChangeApp(Tests.SHARED_SIGNIN).execute();
+        authApi = admin.getClient(AuthenticationApi.class);
+        authApi.changeApp(Tests.SHARED_SIGNIN).execute();
         adminSurveysApi = admin.getClient(SurveysApi.class);
     }
 
@@ -112,13 +112,13 @@ public class SharedModuleMetadataTest {
         surveyCreatedOn = retSurvey.getCreatedOn();
 
         // Ensure all tests are consistent by having the admin start in the API app.
-        superadminsApi.adminChangeApp(API_SIGNIN).execute();
+        authApi.changeApp(API_SIGNIN).execute();
     }
 
     @SuppressWarnings("deprecation")
     @After
     public void after() throws Exception {
-        superadminsApi.adminChangeApp(SHARED_SIGNIN).execute();
+        authApi.changeApp(SHARED_SIGNIN).execute();
         try {
             adminsApi.deleteMetadataByIdAllVersions(moduleId, true).execute();
         } catch (EntityNotFoundException ex) {
@@ -129,7 +129,7 @@ public class SharedModuleMetadataTest {
             adminsApi.deleteAllRevisionsOfUploadSchema(schemaId, true).execute();
             adminSurveysApi.deleteSurvey(surveyGuid, surveyCreatedOn, true).execute();
         } finally {
-            superadminsApi.adminChangeApp(API_SIGNIN).execute();
+            authApi.changeApp(API_SIGNIN).execute();
         }
     }
     
@@ -277,7 +277,7 @@ public class SharedModuleMetadataTest {
         assertEquals(updatedMetadataV6, gettedByIdAndVersionV6);
 
         // Delete v2. Latest is still v6.
-        superadminsApi.adminChangeApp(SHARED_SIGNIN).execute();
+        authApi.changeApp(SHARED_SIGNIN).execute();
         adminsApi.deleteMetadataByIdAndVersion(moduleId, 2, true).execute();
         SharedModuleMetadata gettedLatestAfterDeleteV2 = sharedDeveloperModulesApi.getMetadataByIdLatestVersion(
                 moduleId).execute().body();
@@ -505,7 +505,7 @@ public class SharedModuleMetadataTest {
             assertFalse(moduleMetadataListContains(case13MetadataList, moduleBV2));
             
             // Verify physical delete
-            superadminsApi.adminChangeApp(SHARED_SIGNIN).execute();
+            authApi.changeApp(SHARED_SIGNIN).execute();
             adminsApi.deleteMetadataByIdAndVersion(moduleAV1.getId(), moduleAV1.getVersion(), true).execute();
             try {
                 sharedDeveloperModulesApi.getMetadataByIdAndVersion(moduleAV1.getId(), moduleAV1.getVersion()).execute();
@@ -513,7 +513,7 @@ public class SharedModuleMetadataTest {
             } catch(EntityNotFoundException e) {
             }
         } finally {
-            superadminsApi.adminChangeApp(SHARED_SIGNIN).execute();
+            authApi.changeApp(SHARED_SIGNIN).execute();
             try {
                 adminsApi.deleteMetadataByIdAllVersions(moduleId + "A", true).execute();
             } catch (BridgeSDKException ex) {
@@ -602,7 +602,7 @@ public class SharedModuleMetadataTest {
             assertTrue(case4MetadataList.contains(moduleV3));
         } finally {
             try {
-                superadminsApi.adminChangeApp(SHARED_SIGNIN).execute();
+                authApi.changeApp(SHARED_SIGNIN).execute();
                 adminsApi.deleteMetadataByIdAllVersions(moduleId + "other", true).execute();
             } catch (BridgeSDKException ex) {
                 LOG.error("Error deleting module " + moduleId + "other: " + ex.getMessage(), ex);
@@ -613,14 +613,14 @@ public class SharedModuleMetadataTest {
     @SuppressWarnings("deprecation")
     @Test(expected = EntityNotFoundException.class)
     public void deleteByIdAllVersions404() throws Exception {
-        superadminsApi.adminChangeApp(SHARED_SIGNIN).execute();
+        authApi.changeApp(SHARED_SIGNIN).execute();
         adminsApi.deleteMetadataByIdAllVersions(moduleId, true).execute();
     }
 
     @SuppressWarnings("deprecation")
     @Test(expected = EntityNotFoundException.class)
     public void deleteByIdAndVersion404() throws Exception {
-        superadminsApi.adminChangeApp(SHARED_SIGNIN).execute();
+        authApi.changeApp(SHARED_SIGNIN).execute();
         adminsApi.deleteMetadataByIdAndVersion(moduleId, 1, true).execute();
     }
 
@@ -712,7 +712,7 @@ public class SharedModuleMetadataTest {
             assertEquals(2, list.getItems().size());
 
         } finally {
-            superadminsApi.adminChangeApp(SHARED_SIGNIN).execute();
+            authApi.changeApp(SHARED_SIGNIN).execute();
             adminsApi.deleteMetadataByIdAllVersions(moduleId + "A", true).execute();
             adminsApi.deleteMetadataByIdAllVersions(moduleId + "B", true).execute();
         }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SharedModuleTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SharedModuleTest.java
@@ -17,9 +17,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
 import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ForDevelopersApi;
-import org.sagebionetworks.bridge.rest.api.ForSuperadminsApi;
 import org.sagebionetworks.bridge.rest.api.SurveysApi;
 import org.sagebionetworks.bridge.rest.api.UploadSchemasApi;
 import org.sagebionetworks.bridge.rest.exceptions.BadRequestException;
@@ -82,16 +82,16 @@ public class SharedModuleTest {
         // Delete schemas created by test. We do it in a single After method instead of multiple, in case there are any
         // referential integrity concerns.
         ForAdminsApi adminApi = admin.getClient(ForAdminsApi.class);
-        ForSuperadminsApi superadminApi = admin.getClient(ForSuperadminsApi.class);
+        AuthenticationApi authApi = admin.getClient(AuthenticationApi.class);
 
         if (module != null) {
             try {
-                superadminApi.adminChangeApp(SHARED_SIGNIN).execute();
+                authApi.changeApp(SHARED_SIGNIN).execute();
                 adminApi.deleteMetadataByIdAllVersions(module.getId(), true).execute();
             } catch (BridgeSDKException ex) {
                 LOG.error("Error deleting module " + module.getId() + ": "  + ex.getMessage(), ex);
             } finally {
-                superadminApi.adminChangeApp(API_SIGNIN).execute();
+                authApi.changeApp(API_SIGNIN).execute();
             }
         }
 
@@ -107,13 +107,13 @@ public class SharedModuleTest {
 
         if (sharedSchema != null) {
             try {
-                superadminApi.adminChangeApp(SHARED_SIGNIN).execute();
+                authApi.changeApp(SHARED_SIGNIN).execute();
                 adminApi.deleteAllRevisionsOfUploadSchema(sharedSchema.getSchemaId(), true).execute();
             } catch (BridgeSDKException ex) {
                 LOG.error("Error deleting schema " + sharedSchema.getSchemaId() + " in app " +
                         sharedDeveloper.getAppId() + ": "  + ex.getMessage(), ex);
             } finally {
-                superadminApi.adminChangeApp(API_SIGNIN).execute();
+                authApi.changeApp(API_SIGNIN).execute();
             }
         }
 
@@ -127,12 +127,12 @@ public class SharedModuleTest {
 
         if (sharedSurvey != null) {
             try {
-                superadminApi.adminChangeApp(SHARED_SIGNIN).execute();
+                authApi.changeApp(SHARED_SIGNIN).execute();
                 adminApi.deleteSurvey(sharedSurvey.getGuid(), sharedSurvey.getCreatedOn(), true).execute();
             } catch (BridgeSDKException ex) {
                 LOG.error("Error deleting shared survey " + sharedSurvey.getGuid() + ": "  + ex.getMessage(), ex);
             } finally {
-                superadminApi.adminChangeApp(API_SIGNIN).execute();
+                authApi.changeApp(API_SIGNIN).execute();
             }
         }
     }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignUpTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignUpTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.sdk.integration;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
 import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ForSuperadminsApi;
@@ -42,6 +43,7 @@ import static org.sagebionetworks.bridge.util.IntegTestUtils.SAGE_ID;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.SHARED_APP_ID;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_ID;
 
+@Category(IntegrationSmokeTest.class)
 public class SignUpTest {
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyLifecycleTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyLifecycleTest.java
@@ -18,7 +18,7 @@ import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
+import org.junit.experimental.categories.Category;
 import org.sagebionetworks.bridge.rest.api.SchedulesV2Api;
 import org.sagebionetworks.bridge.rest.api.StudiesApi;
 import org.sagebionetworks.bridge.rest.exceptions.BadRequestException;
@@ -31,6 +31,7 @@ import org.sagebionetworks.bridge.user.TestUserHelper.TestUser;
 
 import retrofit2.Call;
 
+@Category(IntegrationSmokeTest.class)
 public class StudyLifecycleTest {
     
     @FunctionalInterface

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
@@ -58,6 +58,8 @@ import static org.sagebionetworks.bridge.sdk.integration.TestSurvey.YEARMONTH_ID
 import static org.sagebionetworks.bridge.sdk.integration.TestSurvey.YEARMONTH_QUESTION_EARLIEST_VALUE;
 import static org.sagebionetworks.bridge.sdk.integration.TestSurvey.YEARMONTH_QUESTION_LATEST_VALUE;
 import static org.sagebionetworks.bridge.sdk.integration.TestSurvey.YEAR_ID;
+import static org.sagebionetworks.bridge.sdk.integration.Tests.API_SIGNIN;
+import static org.sagebionetworks.bridge.sdk.integration.Tests.SHARED_SIGNIN;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.SHARED_APP_ID;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_ID;
 import static org.sagebionetworks.bridge.sdk.integration.TestSurvey.POSTALCODE_ID;
@@ -81,10 +83,10 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
 import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
 import org.sagebionetworks.bridge.rest.api.ForDevelopersApi;
-import org.sagebionetworks.bridge.rest.api.ForSuperadminsApi;
 import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
 import org.sagebionetworks.bridge.rest.api.SchedulesV1Api;
 import org.sagebionetworks.bridge.rest.api.SurveysApi;
@@ -152,7 +154,7 @@ public class SurveyTest {
     private static ForDevelopersApi sharedDeveloperModulesApi;
     private static SurveysApi sharedSurveysApi;
     private static ForAdminsApi adminsApi;
-    private static ForSuperadminsApi superadminsApi;
+    private static AuthenticationApi authApi;
 
     private String surveyId;
 
@@ -164,7 +166,7 @@ public class SurveyTest {
     public static void beforeClass() throws Exception {
         TestUser admin = TestUserHelper.getSignedInAdmin();
         adminsApi = admin.getClient(ForAdminsApi.class);
-        superadminsApi = admin.getClient(ForSuperadminsApi.class);
+        authApi = admin.getClient(AuthenticationApi.class);
         developer = TestUserHelper.createAndSignInUser(SurveyTest.class, false, Role.DEVELOPER);
         user = TestUserHelper.createAndSignInUser(SurveyTest.class, true);
         worker = TestUserHelper.createAndSignInUser(SurveyTest.class, false, Role.WORKER);
@@ -419,7 +421,7 @@ public class SurveyTest {
         // execute delete
         Exception thrownEx = null;
         try {
-            superadminsApi.adminChangeApp(Tests.SHARED_SIGNIN).execute();
+            authApi.changeApp(SHARED_SIGNIN).execute();
             adminsApi.deleteSurvey(retSurvey.getGuid(), retSurvey.getCreatedOn(), true).execute();
             fail("expected exception");
         } catch (BadRequestException e) {
@@ -428,7 +430,7 @@ public class SurveyTest {
             // finally delete shared module and uploaded schema
             adminsApi.deleteMetadataByIdAllVersions(moduleId, true).execute();
             adminsApi.deleteSurvey(retSurvey.getGuid(), retSurvey.getCreatedOn(), true).execute();
-            superadminsApi.adminChangeApp(Tests.API_SIGNIN).execute();
+            authApi.changeApp(API_SIGNIN).execute();
         }
         assertNotNull(thrownEx);
     }
@@ -455,7 +457,7 @@ public class SurveyTest {
         // execute delete
         Exception thrownEx = null;
         try {
-            superadminsApi.adminChangeApp(Tests.SHARED_SIGNIN).execute();
+            authApi.changeApp(SHARED_SIGNIN).execute();
             adminsApi.deleteSurvey(IDENTIFIER_PREFIX+survey.getIdentifier(), retSurvey.getCreatedOn(), true).execute();
             fail("expected exception");
         } catch (BadRequestException e) {
@@ -464,7 +466,7 @@ public class SurveyTest {
             // finally delete shared module and uploaded schema
             adminsApi.deleteMetadataByIdAllVersions(moduleId, true).execute();
             adminsApi.deleteSurvey(IDENTIFIER_PREFIX+survey.getIdentifier(), retSurvey.getCreatedOn(), true).execute();
-            superadminsApi.adminChangeApp(Tests.API_SIGNIN).execute();
+            authApi.changeApp(API_SIGNIN).execute();
         }
         assertNotNull(thrownEx);
     }
@@ -492,10 +494,10 @@ public class SurveyTest {
             thrownEx = e;
         } finally {
             // finally delete shared module and uploaded schema
-            superadminsApi.adminChangeApp(Tests.SHARED_SIGNIN).execute();
+            authApi.changeApp(SHARED_SIGNIN).execute();
             adminsApi.deleteMetadataByIdAllVersions(moduleId, true).execute();
             adminsApi.deleteSurvey(retSurvey.getGuid(), retSurvey.getCreatedOn(), true).execute();
-            superadminsApi.adminChangeApp(Tests.API_SIGNIN).execute();
+            authApi.changeApp(API_SIGNIN).execute();
         }
         assertNotNull(thrownEx);
     }
@@ -528,10 +530,10 @@ public class SurveyTest {
             thrownEx = e;
         } finally {
             // finally delete shared module and uploaded schema
-            superadminsApi.adminChangeApp(Tests.SHARED_SIGNIN).execute();
+            authApi.changeApp(SHARED_SIGNIN).execute();
             adminsApi.deleteMetadataByIdAllVersions(moduleId, true).execute();
             adminsApi.deleteSurvey(IDENTIFIER_PREFIX+survey.getIdentifier(), retSurvey.getCreatedOn(), true).execute();
-            superadminsApi.adminChangeApp(Tests.API_SIGNIN).execute();
+            authApi.changeApp(API_SIGNIN).execute();
         }
         assertNotNull(thrownEx);
     }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
@@ -5,14 +5,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.rest.model.ActivityEventUpdateType.FUTURE_ONLY;
 import static org.sagebionetworks.bridge.rest.model.ActivityEventUpdateType.MUTABLE;
+import static org.sagebionetworks.bridge.util.IntegTestUtils.CONFIG;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.SHARED_APP_ID;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_ID;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -32,8 +30,6 @@ import org.sagebionetworks.client.SynapseClientImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.sagebionetworks.bridge.config.Config;
-import org.sagebionetworks.bridge.config.PropertiesConfig;
 import org.sagebionetworks.bridge.rest.ApiClientProvider;
 import org.sagebionetworks.bridge.rest.ClientManager;
 import org.sagebionetworks.bridge.rest.RestUtils;
@@ -77,12 +73,6 @@ public class Tests {
 
     private static final int RETRY_MAX_TRIES = 5;
     private static final long RETRY_SLEEP_MILLIS = 1000;
-
-    private static final String CONFIG_FILE = "bridge-sdk-test.properties";
-    private static final String DEFAULT_CONFIG_FILE = CONFIG_FILE;
-    private static final String USER_CONFIG_FILE = System.getProperty("user.home") + "/" + CONFIG_FILE;
-
-    private static Config config;
 
     public static ClientInfo getClientInfoWithVersion(String osName, int version) {
         return new ClientInfo().appName(APP_NAME).appVersion(version).deviceName(APP_NAME).osName(osName)
@@ -366,30 +356,14 @@ public class Tests {
         assertEquals(ImmutableSet.copyOf(list1), ImmutableSet.copyOf(list2));
     }
 
-    public static Config loadTestConfig() throws IOException {
-        if (config != null) {
-            return config;
-        }
-
-        Path localConfigPath = Paths.get(USER_CONFIG_FILE);
-        if (Files.exists(localConfigPath)) {
-            config = new PropertiesConfig(DEFAULT_CONFIG_FILE, localConfigPath);
-        } else {
-            config = new PropertiesConfig(DEFAULT_CONFIG_FILE);
-        }
-        return config;
-    }
-
     public static SynapseClient getSynapseClient() throws IOException {
-        Config config = loadTestConfig();
-
         // Create Synapse Client.
         SynapseClient synapseClient = new SynapseClientImpl();
-        synapseClient.setUsername(config.get("synapse.user"));
-        synapseClient.setApiKey(config.get("synapse.api.key"));
+        synapseClient.setUsername(CONFIG.get("synapse.user"));
+        synapseClient.setApiKey(CONFIG.get("synapse.api.key"));
 
         // Based on config, we either talk to Synapse Dev (local/dev/staging) or Synapse Prod.
-        String synapseEndpoint = config.get("synapse.endpoint");
+        String synapseEndpoint = CONFIG.get("synapse.endpoint");
         synapseClient.setAuthEndpoint(synapseEndpoint + "auth/v1");
         synapseClient.setFileEndpoint(synapseEndpoint + "file/v1");
         synapseClient.setRepositoryEndpoint(synapseEndpoint + "repo/v1");

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
@@ -359,8 +359,8 @@ public class Tests {
     public static SynapseClient getSynapseClient() throws IOException {
         // Create Synapse Client.
         SynapseClient synapseClient = new SynapseClientImpl();
-        synapseClient.setUsername(CONFIG.get("synapse.user"));
-        synapseClient.setApiKey(CONFIG.get("synapse.api.key"));
+        synapseClient.setUsername(CONFIG.get("synapse.test.user"));
+        synapseClient.setApiKey(CONFIG.get("synapse.test.user.api.key"));
 
         // Based on config, we either talk to Synapse Dev (local/dev/staging) or Synapse Prod.
         String synapseEndpoint = CONFIG.get("synapse.endpoint");

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UTF8Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UTF8Test.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.sdk.integration;
 
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
 import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
 import org.sagebionetworks.bridge.rest.api.ForSuperadminsApi;
@@ -15,13 +14,14 @@ import org.sagebionetworks.bridge.user.TestUserHelper.TestUser;
 import static org.junit.Assert.assertEquals;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.API_SIGNIN;
 
-@Category(IntegrationSmokeTest.class)
 public class UTF8Test {
     @Test
     public void canSaveAndRetrieveDataStoredInDynamo() throws Exception {
         String appId = Tests.randomIdentifier(getClass());
         String appName = "☃지구상의　３대　극지라　불리는";
-        ForSuperadminsApi superadminApi = TestUserHelper.getSignedInAdmin().getClient(ForSuperadminsApi.class);
+        TestUser admin = TestUserHelper.getSignedInAdmin();
+        ForSuperadminsApi superadminApi = admin.getClient(ForSuperadminsApi.class);
+        AuthenticationApi authApi = admin.getClient(AuthenticationApi.class);
 
         // make minimal study
         App app = new App();
@@ -37,14 +37,14 @@ public class UTF8Test {
         superadminApi.createApp(app).execute();
 
         try {
-            superadminApi.adminChangeApp(new SignIn().appId(appId)).execute();
+            authApi.changeApp(new SignIn().appId(appId)).execute();
             
             // get study back and verify fields
             App returnedApp = superadminApi.getApp(appId).execute().body();
             assertEquals(appId, returnedApp.getIdentifier());
             assertEquals(appName, returnedApp.getName());
         } finally {
-            superadminApi.adminChangeApp(API_SIGNIN).execute();
+            authApi.changeApp(API_SIGNIN).execute();
             // clean-up: delete study
             superadminApi.deleteApp(appId, true).execute();
         }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
@@ -31,10 +31,9 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
+import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
 import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ForDevelopersApi;
-import org.sagebionetworks.bridge.rest.api.ForSuperadminsApi;
 import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
 import org.sagebionetworks.bridge.rest.api.UploadSchemasApi;
 import org.sagebionetworks.bridge.rest.exceptions.BadRequestException;
@@ -60,7 +59,7 @@ public class UploadSchemaTest {
     private static TestUserHelper.TestUser worker;
     private static TestUserHelper.TestUser sharedDeveloper;
     private static ForAdminsApi adminApi;
-    private static ForSuperadminsApi superadminApi;
+    private static AuthenticationApi authApi;
     private static UploadSchemasApi devUploadSchemasApi;
     private static ForWorkersApi workerUploadSchemasApi;
     private static ForDevelopersApi sharedDeveloperModulesApi;
@@ -78,7 +77,7 @@ public class UploadSchemaTest {
         sharedDeveloperModulesApi = sharedDeveloper.getClient(ForDevelopersApi.class);
 
         adminApi = admin.getClient(ForAdminsApi.class);
-        superadminApi = admin.getClient(ForSuperadminsApi.class);
+        authApi = admin.getClient(AuthenticationApi.class);
         devUploadSchemasApi = developer.getClient(UploadSchemasApi.class);
         sharedUploadSchemasApi = sharedDeveloper.getClient(UploadSchemasApi.class);
         workerUploadSchemasApi = worker.getClient(ForWorkersApi.class);
@@ -93,7 +92,7 @@ public class UploadSchemaTest {
     @After
     public void deleteSchemas() throws Exception {
         try {
-            superadminApi.adminChangeApp(API_SIGNIN).execute();
+            authApi.changeApp(API_SIGNIN).execute();
             adminApi.deleteAllRevisionsOfUploadSchema(schemaId, true).execute();
         } catch (EntityNotFoundException ex) {
             // Suppress the exception, as the test may have already deleted the schema.
@@ -145,9 +144,9 @@ public class UploadSchemaTest {
         // execute delete
         Exception thrownEx = null;
         try {
-            superadminApi.adminChangeApp(SHARED_SIGNIN).execute();
+            authApi.changeApp(SHARED_SIGNIN).execute();
             adminApi.deleteAllRevisionsOfUploadSchema(retSchema.getSchemaId(), true).execute();
-            superadminApi.adminChangeApp(API_SIGNIN).execute();
+            authApi.changeApp(API_SIGNIN).execute();
             fail("expected exception");
         } catch (BadRequestException e) {
             thrownEx = e;
@@ -155,9 +154,9 @@ public class UploadSchemaTest {
             // finally delete shared module and uploaded schema
             adminApi.deleteMetadataByIdAllVersions(moduleId, true).execute();
 
-            superadminApi.adminChangeApp(SHARED_SIGNIN).execute();
+            authApi.changeApp(SHARED_SIGNIN).execute();
             adminApi.deleteAllRevisionsOfUploadSchema(retSchema.getSchemaId(), true).execute();
-            superadminApi.adminChangeApp(API_SIGNIN).execute();
+            authApi.changeApp(API_SIGNIN).execute();
         }
         assertNotNull(thrownEx);
     }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.sagebionetworks.bridge.sdk.integration.Tests.API_SIGNIN;
+import static org.sagebionetworks.bridge.sdk.integration.Tests.SHARED_SIGNIN;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.STUDY_ID_1;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.SHARED_APP_ID;
 
@@ -29,6 +31,7 @@ import org.junit.experimental.categories.Category;
 
 import org.sagebionetworks.bridge.json.DefaultObjectMapper;
 import org.sagebionetworks.bridge.rest.RestUtils;
+import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
 import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
 import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
@@ -59,7 +62,6 @@ import org.sagebionetworks.bridge.util.IntegTestUtils;
 import com.google.common.collect.Lists;
 
 @Category(IntegrationSmokeTest.class)
-@SuppressWarnings({ "ConstantConditions", "unchecked" })
 public class UploadTest {
     
     private static final String EXTERNAL_ID = "upload-test-extid";
@@ -72,11 +74,9 @@ public class UploadTest {
     // Retry up to 6 times, so we don't spend more than 30 seconds per test.
     private static final int UPLOAD_STATUS_DELAY_RETRIES = 6;
     
-    private static TestUserHelper.TestUser worker;
     private static TestUserHelper.TestUser developer;
-    private static TestUserHelper.TestUser otherStudyAdmin;
+    private static TestUserHelper.TestUser otherAppAdmin;
     private static TestUserHelper.TestUser researcher;
-    private static TestUserHelper.TestUser studyAdmin;
     private static TestUserHelper.TestUser user;
     private static TestUserHelper.TestUser admin;
 
@@ -94,11 +94,12 @@ public class UploadTest {
         }
         
         // developer is to ensure schemas exist. user is to do uploads
-        worker = TestUserHelper.createAndSignInUser(UploadTest.class, false, Role.WORKER);
         developer = TestUserHelper.createAndSignInUser(UploadTest.class, false, Role.DEVELOPER);
-        otherStudyAdmin = TestUserHelper.createAndSignInUser(UploadTest.class, SHARED_APP_ID, Role.ADMIN);
         researcher = TestUserHelper.createAndSignInUser(UploadTest.class, false, Role.RESEARCHER);
-        studyAdmin = TestUserHelper.createAndSignInUser(UploadTest.class, false, Role.ADMIN);
+
+        admin.getClient(AuthenticationApi.class).changeApp(SHARED_SIGNIN).execute();
+        otherAppAdmin = TestUserHelper.createAndSignInUser(UploadTest.class, SHARED_APP_ID, Role.ADMIN);
+        admin.getClient(AuthenticationApi.class).changeApp(API_SIGNIN).execute();
 
         String emailAddress = IntegTestUtils.makeEmail(UploadTest.class);
         SignUp signUp = new SignUp().email(emailAddress).password(Tests.PASSWORD);
@@ -178,13 +179,6 @@ public class UploadTest {
     }
 
     @AfterClass
-    public static void deleteWorker() throws Exception {
-        if (worker != null) {
-            worker.signOutAndDeleteUser();
-        }
-    }
-
-    @AfterClass
     public static void deleteDeveloper() throws Exception {
         if (developer != null) {
             developer.signOutAndDeleteUser();
@@ -193,8 +187,8 @@ public class UploadTest {
 
     @AfterClass
     public static void deleteOtherStudyAdmin() throws Exception {
-        if (otherStudyAdmin != null) {
-            otherStudyAdmin.signOutAndDeleteUser();
+        if (otherAppAdmin != null) {
+            otherAppAdmin.signOutAndDeleteUser();
         }
     }
 
@@ -202,13 +196,6 @@ public class UploadTest {
     public static void deleteResearcher() throws Exception {
         if (researcher != null) {
             researcher.signOutAndDeleteUser();
-        }
-    }
-
-    @AfterClass
-    public static void deleteStudyAdmin() throws Exception {
-        if (studyAdmin != null) {
-            studyAdmin.signOutAndDeleteUser();
         }
     }
 
@@ -316,8 +303,8 @@ public class UploadTest {
         }
         // userClient.upload marks the download complete
         // marking an already completed download as complete again should succeed (and be a no-op)
-        worker.getClient(ForWorkersApi.class).completeUploadSession(session.getId(), false, false)
-                .execute();
+        admin.getClient(ForWorkersApi.class)
+            .completeUploadSession(session.getId(), false, false).execute();
 
         validateUploadValidationStatus(uploadId, status);
 
@@ -328,7 +315,8 @@ public class UploadTest {
         RecordExportStatusRequest statusRequest = new RecordExportStatusRequest();
         statusRequest.setRecordIds(ImmutableList.of(record.getId()));
         statusRequest.setSynapseExporterStatus(SynapseExporterStatus.NOT_EXPORTED);
-        worker.getClient(ForWorkersApi.class).updateRecordExportStatuses(statusRequest).execute();
+        admin.getClient(ForWorkersApi.class)
+            .updateRecordExportStatuses(statusRequest).execute();
 
         status = usersApi.getUploadStatus(session.getId()).execute().body();
         assertEquals(SynapseExporterStatus.NOT_EXPORTED, status.getRecord().getSynapseExporterStatus());
@@ -387,25 +375,22 @@ public class UploadTest {
         assertNotNull(retrieved2.getHealthData());
         assertEquals(retrieved1, retrieved2);
 
-        // Worker can also retrieve this records.
-        ForWorkersApi workerApi = worker.getClient(ForWorkersApi.class);
+        // this is the same API used by workers, but in a smoke test on production,
+        // our ADMIN account cannot create a worker.
+        ForAdminsApi studyAdminApi = admin.getClient(ForAdminsApi.class);
 
-        Upload retrieved3 = workerApi.getUploadById(status.getId()).execute().body();
-        Upload retrieved4 = workerApi.getUploadByRecordId(record.getId()).execute().body();
+        Upload retrieved3 = studyAdminApi.getUploadById(status.getId()).execute().body();
+        Upload retrieved4 = studyAdminApi.getUploadByRecordId(record.getId()).execute().body();
 
         assertNotNull(retrieved3.getHealthData());
         assertNotNull(retrieved4.getHealthData());
         assertEquals(retrieved3, retrieved4);
 
-        // Study admin can also retrieve this record.
-        ForAdminsApi studyAdminApi = studyAdmin.getClient(ForAdminsApi.class);
-        studyAdminApi.getUploadById(status.getId()).execute();
-        studyAdminApi.getUploadByRecordId(record.getId()).execute();
-
         // Other study admin cannot retrieve this record.
-        ForAdminsApi otherStudyAdminApi = otherStudyAdmin.getClient(ForAdminsApi.class);
+        ForAdminsApi otherStudyAdminApi = otherAppAdmin.getClient(ForAdminsApi.class);
         try {
-            otherStudyAdminApi.getUploadById(status.getId()).execute();
+            Upload retValue = otherStudyAdminApi.getUploadById(status.getId()).execute().body();
+            System.out.println(retValue);
             fail("exception expected");
         } catch (UnauthorizedException ex) {
             // expected exception

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserManagementTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserManagementTest.java
@@ -97,6 +97,7 @@ public class UserManagementTest {
         admin.signOut();
         
         ForSuperadminsApi superadminApi = admin.getClient(ForSuperadminsApi.class);
+        AuthenticationApi authApi = admin.getClient(AuthenticationApi.class);
         SignIn signIn = new SignIn().appId(admin.getAppId())
                 .email(admin.getEmail()).password((admin.getPassword()));
         
@@ -105,7 +106,7 @@ public class UserManagementTest {
         assertEquals(TEST_APP_ID, currentApp.getIdentifier());
         
         superadminApi = admin.getClient(ForSuperadminsApi.class);
-        superadminApi.adminChangeApp(SHARED_SIGNIN).execute().body();
+        authApi.changeApp(SHARED_SIGNIN).execute().body();
         
         currentApp = admin.getClient(AppsApi.class).getUsersApp().execute().body();
         assertEquals(SHARED_APP_ID, currentApp.getIdentifier());
@@ -122,7 +123,7 @@ public class UserManagementTest {
         assertEquals(SHARED_APP_ID, currentApp.getIdentifier());
         
         superadminApi = admin.getClient(ForSuperadminsApi.class);
-        superadminApi.adminChangeApp(API_SIGNIN).execute().body();
+        authApi.changeApp(API_SIGNIN).execute().body();
         
         currentApp = admin.getClient(AppsApi.class).getUsersApp().execute().body();
         assertEquals(TEST_APP_ID, currentApp.getIdentifier());

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/WorkerApiTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/WorkerApiTest.java
@@ -26,8 +26,9 @@ import org.junit.Test;
 
 import org.sagebionetworks.bridge.rest.RestUtils;
 import org.sagebionetworks.bridge.rest.api.ActivitiesApi;
+import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
+import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
 import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
-import org.sagebionetworks.bridge.rest.api.ForSuperadminsApi;
 import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
 import org.sagebionetworks.bridge.rest.api.InternalApi;
 import org.sagebionetworks.bridge.rest.api.SchedulesV1Api;
@@ -76,11 +77,11 @@ public class WorkerApiTest {
         workersApi = worker.getClient(ForWorkersApi.class);
         
         // Turn on healthcode sharing, it is usually off 
-        ForSuperadminsApi superadminApi = admin.getClient(ForSuperadminsApi.class);
-        App app = superadminApi.getApp(TEST_APP_ID).execute().body();
+        ForAdminsApi adminApi = admin.getClient(ForAdminsApi.class);
+        App app = adminApi.getUsersApp().execute().body();
         if (!app.isHealthCodeExportEnabled()) {
             app.setHealthCodeExportEnabled(true);
-            superadminApi.updateApp(TEST_APP_ID, app).execute();
+            adminApi.updateUsersApp(app).execute();
         }
     }
 
@@ -91,11 +92,11 @@ public class WorkerApiTest {
         }
 
         // Turn off healthcode sharing to clean up
-        ForSuperadminsApi superadminApi = admin.getClient(ForSuperadminsApi.class);
-        App app = superadminApi.getApp(TEST_APP_ID).execute().body();
+        ForAdminsApi authApi = admin.getClient(ForAdminsApi.class);
+        App app = authApi.getUsersApp().execute().body();
         if (app.isHealthCodeExportEnabled()) {
             app.setHealthCodeExportEnabled(false);
-            superadminApi.updateApp(TEST_APP_ID, app).execute();
+            authApi.updateUsersApp(app).execute();
         }
     }
     @After
@@ -347,11 +348,11 @@ public class WorkerApiTest {
      */
     @Test
     public void retrieveUsersBetweenApps() throws Exception {
-        ForSuperadminsApi adminsApi = admin.getClient(ForSuperadminsApi.class);
-        adminsApi.adminChangeApp(new SignIn().appId(SHARED_APP_ID)).execute();
+        AuthenticationApi authApi = admin.getClient(AuthenticationApi.class);
+        authApi.changeApp(new SignIn().appId(SHARED_APP_ID)).execute();
         TestUser sharedUser = new TestUserHelper.Builder(WorkerApiTest.class).withAppId(SHARED_APP_ID).createUser();
         
-        adminsApi.adminChangeApp(new SignIn().appId(TEST_APP_ID)).execute();
+        authApi.changeApp(new SignIn().appId(TEST_APP_ID)).execute();
         TestUser testUser = new TestUserHelper.Builder(WorkerApiTest.class).withAppId(TEST_APP_ID).createUser();
         
         // This worker is by default in Sage Bionetworks, and thus is associated to studies in the 'api'


### PR DESCRIPTION
- Changed all tests to use preferred methods that replace the two removed superadmin APIs;
- Changed smoke tests so they only need an admin to run (removed UTF-8 test because it's definitely not necessary in the smoke tests, and added a couple of others that seemed important, but I'm flexible about which tests we include in this set).