### PR TITLE
Adjusting tests based on using an admin who signs in via Synapse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # BridgeIntegrationTests
 
-Integration tests for the BridgeServer2 server. Integration tests require a bootstrap account on the server to execute. Outside of production, the full suite of tests runs using  `SUPERADMIN` account. On production, for security reasons, a subset of these tests execute using an `ADMIN` account. (The `ADMIN` account can’t access all apps, or create worker accounts that can access all apps.)
-
-The production tests are marked with the `@Category(IntegrationSmokeTest.class)` class annotation.
+Integration tests for the BridgeServer2 server. Integration tests require bootstrap accounts on the server to execute. All tests run outside of production using a `SUPERADMIN` account. In production, for security reasons, a subset of these tests execute using an `ADMIN` account (marked with the `@Category(IntegrationSmokeTest.class)` class annotation). The `ADMIN` account can’t access all apps, or create worker accounts that can access all apps.
 
 ## Setting up your environment to run integration tests
 
@@ -18,16 +16,13 @@ The integration tests use the Bridge Java REST SDK, and both the SDK and the tes
 
     dev.name = <dev name>
 
-    admin.email = <email address>
-    admin.password = <password>
-
     synapse.test.user = <user name>
     synapse.test.user.id = <numerical account ID>
     synapse.test.user.password = <password>
     synapse.test.user.api.key = <api key>
 
-**admin.email** and **admin.password:** Create an account with the `SUPERADMIN` role outside of production and the `ADMIN` role in production. This account should be created in the 'api' and 'shared' apps, with the same email and password, and the same synapse user ID of 0000 (four zeroes) in both apps (this allows an `ADMIN` account to to switch between these two studies). These are test apps, so accidents in these apps would not impact other production apps.
+Create two bootstrap accounts in each environment, one in the 'api' app and one in the 'shared' app. Each account should have the `synapseUserId` ID set in the `synapse.test.user.id` property. In production these accounts should have the `ADMIN` role and in other environments, these accounts should have the `SUPERADMIN` role.
 
-The **synapse.test.*** keys are available in LastPass.
+The **synapse.test.*** keys for environments other than `local` are available in LastPass.
 
-It should be possible to start the server and run `mvn clean test` at this point.
+It should be possible at this point to start the server and run the tests (`mvn clean test`).

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>BridgeIntegTestUtils</artifactId>
-            <version>1.2.7</version>
+            <version>1.2.8</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>BridgeIntegTestUtils</artifactId>
-            <version>1.2.8</version>
+            <version>1.2.9</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AppTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AppTest.java
@@ -93,7 +93,8 @@ public class AppTest {
     @Before
     public void before() throws IOException {
         admin = TestUserHelper.getSignedInAdmin();
-        synapseClient = Tests.getSynapseClient();
+        // This signs out our admin since it uses the same credentials.
+        // synapseClient = Tests.getSynapseClient();
     }
 
     @After
@@ -107,7 +108,6 @@ public class AppTest {
         if (team != null) {
             synapseClient.deleteTeam(team.getId());
         }
-        admin.signOut();
     }
 
     // Disabled this test: This test stomps the Synapse configuration in the API app. This is used by the

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthForWorkerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthForWorkerTest.java
@@ -8,6 +8,7 @@ import static org.sagebionetworks.bridge.util.IntegTestUtils.CONFIG;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.sagebionetworks.bridge.rest.api.ForSuperadminsApi;
 import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
@@ -22,6 +23,7 @@ import org.sagebionetworks.bridge.user.TestUserHelper.TestUser;
 
 import com.google.common.collect.ImmutableList;
 
+@Ignore // For this test to pass, we'll need a second Synapse ID that can be assigned to the worker. 
 public class OAuthForWorkerTest {
     
     private TestUser admin;

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthTest.java
@@ -2,7 +2,7 @@ package org.sagebionetworks.bridge.sdk.integration;
 
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toSet;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.sagebionetworks.bridge.rest.model.Role.DEVELOPER;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.API_SIGNIN;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.SHARED_SIGNIN;
@@ -24,19 +24,21 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
+import org.sagebionetworks.bridge.rest.ClientManager;
 import org.sagebionetworks.bridge.rest.RestUtils;
 import org.sagebionetworks.bridge.rest.api.AppsApi;
 import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
 import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
 import org.sagebionetworks.bridge.rest.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.rest.exceptions.UnauthorizedException;
+import org.sagebionetworks.bridge.rest.model.App;
 import org.sagebionetworks.bridge.rest.model.AppList;
 import org.sagebionetworks.bridge.rest.model.Environment;
 import org.sagebionetworks.bridge.rest.model.OAuthAuthorizationToken;
 import org.sagebionetworks.bridge.rest.model.SignIn;
-import org.sagebionetworks.bridge.rest.model.SignUp;
 import org.sagebionetworks.bridge.rest.model.UserSessionInfo;
 import org.sagebionetworks.bridge.user.TestUserHelper;
 import org.sagebionetworks.bridge.user.TestUserHelper.TestUser;
@@ -48,33 +50,25 @@ public class OAuthTest {
 
     private TestUser admin;
     private TestUser user;
-    private TestUser user2;
-    private TestUser developer;
-
+    
+    private String adminUserId;
+    
     @Before
     public void before() throws Exception {
-        admin = TestUserHelper.getSignedInAdmin();
+        admin = TestUserHelper.getSignedInAdmin(true);
+        adminUserId = admin.getUserId();
     }
     
     @After
     public void after() throws Exception {
-        // Force admin back to the API test
-        admin.signOut();
         if (user != null) {
             user.signOutAndDeleteUser();
-        }
-        if (developer != null) {
-            developer.signOutAndDeleteUser();
-        }
-        if (user2 != null) {
-            user2.signOutAndDeleteUser();
         }
     }
     
     @Test(expected = EntityNotFoundException.class)
     public void requestOAuthAccessTokenExists() throws Exception {
         user = TestUserHelper.createAndSignInUser(OAuthTest.class, true);
-        
         ForConsentedUsersApi usersApi = user.getClient(ForConsentedUsersApi.class);
         
         OAuthAuthorizationToken token = new OAuthAuthorizationToken().authToken("authToken");
@@ -93,10 +87,7 @@ public class OAuthTest {
         String userPassword = CONFIG.get("synapse.test.user.password");
         String synapseUserId = CONFIG.get("synapse.test.user.id");
         
-        developer = TestUserHelper.createAndSignInUser(OAuthTest.class, true,
-                new SignUp().roles(ImmutableList.of(DEVELOPER)).synapseUserId(synapseUserId));
-        developer.signOut();
-
+        // this is the admin user, so the account does not need to be created
         // Sign in to Synapse
         String payload = escapeJSON(format("{'username':'%s','password':'%s'}", userEmail, userPassword));
         HttpResponse response = Request.Post(synapseEndpoint + SYNAPSE_LOGIN_URL)
@@ -123,25 +114,30 @@ public class OAuthTest {
                 .authToken(authToken)
                 .callbackUrl("https://research.sagebridge.org");
         
-        AuthenticationApi authApi = developer.getClient(AuthenticationApi.class);
+        // These don't have to be valid credentials, as we're only going to use this client to sign in
+        // via Synapse.
+        ClientManager cm = new ClientManager.Builder().withSignIn(new SignIn().appId(TEST_APP_ID)
+                .email(userEmail).password(userPassword)).build();
+        AuthenticationApi authApi = cm.getClient(AuthenticationApi.class);
+
         UserSessionInfo session = authApi.signInWithOauthToken(token).execute().body();
         
-        assertEquals(session.getId(), developer.getSession().getId());
-        assertEquals(session.getSynapseUserId(), developer.getSession().getSynapseUserId());
+        assertEquals(session.getId(), adminUserId);
+        assertEquals(session.getSynapseUserId(), synapseUserId);
     }
     
     @Test
     public void signInWithSynapseAccountUsingRestUtils() throws Exception {
-        String synapseUserId = CONFIG.get("synapse.test.user.id");
-        developer = TestUserHelper.createAndSignInUser(OAuthTest.class, true,
-                new SignUp().roles(ImmutableList.of(DEVELOPER)).synapseUserId(synapseUserId));
-        
         String userEmail = CONFIG.get("synapse.test.user");
         String userPassword = CONFIG.get("synapse.test.user.password");
-        developer.signOut();
-
+        String synapseUserId = CONFIG.get("synapse.test.user.id");
         SignIn signIn = new SignIn().appId(TEST_APP_ID).email(userEmail).password(userPassword);
-        AuthenticationApi authApi = developer.getClient(AuthenticationApi.class);
+        
+        // These don't have to be valid credentials, as we're only going to use this client to sign in
+        // via Synapse.
+        ClientManager cm = new ClientManager.Builder().withSignIn(new SignIn().appId(TEST_APP_ID)
+                .email(userEmail).password(userPassword)).build();
+        AuthenticationApi authApi = cm.getClient(AuthenticationApi.class);
         
         UserSessionInfo session;
         if (CONFIG.getEnvironment() == Environment.PRODUCTION) {
@@ -149,51 +145,31 @@ public class OAuthTest {
         } else {
             session = RestUtils.signInWithSynapseDev(authApi, signIn);
         }
-        
-        assertEquals(session.getId(), developer.getSession().getId());
-        assertEquals(session.getSynapseUserId(), developer.getSession().getSynapseUserId());
+        assertEquals(session.getId(), adminUserId);
+        assertEquals(session.getSynapseUserId(), synapseUserId);
     }
     
     @Test
     public void synapseUserCanSwitchBetweenStudies() throws Exception {
-        // Going to use the shared app as well as the API app for this test.
-        String synapseUserId = CONFIG.get("synapse.test.user.id");
-        
-        user = new TestUserHelper.Builder(OAuthTest.class).withAppId(TEST_APP_ID)
-                .withSignUp(new SignUp().appId(TEST_APP_ID)
-                .roles(ImmutableList.of(DEVELOPER)).synapseUserId(synapseUserId))
-                .createAndSignInUser();
-        String userId = user.getUserId();
-
+        // Use the admin we know to be in two studies.
         admin.getClient(AuthenticationApi.class).changeApp(SHARED_SIGNIN).execute();
-        
-        user2 = new TestUserHelper.Builder(OAuthTest.class).withAppId(SHARED_APP_ID)
-                .withSignUp(new SignUp().appId(SHARED_APP_ID)
-                .roles(ImmutableList.of(DEVELOPER)).synapseUserId(synapseUserId))
-                .createAndSignInUser();
-        String user2Id = user2.getUserId();
-
-        AppsApi appsApi = user2.getClient(AppsApi.class);
-        AppList list = appsApi.getAppMemberships().execute().body();
-        assertEquals(2, list.getItems().size());
-        
-        Set<String> appIds = list.getItems().stream().map(el -> el.getIdentifier()).collect(toSet());
-        assertEquals(ImmutableSet.of(TEST_APP_ID, SHARED_APP_ID), appIds);
-        
-        UserSessionInfo info = appsApi.changeApp(SHARED_SIGNIN).execute().body();
-        assertEquals(user2Id, info.getId());
-        
-        info = appsApi.changeApp(API_SIGNIN).execute().body();
-        assertEquals(userId, info.getId());
-        
-        // Before the admin switches back to the API app, delete this user in the shared app
-        user2.signOutAndDeleteUser();
-        
-        // Verify this has an immediate effect on the other user
-        list = user.getClient(AppsApi.class).getAppMemberships().execute().body();
-        assertEquals(list.getItems().size(), 1);
+        App app = admin.getClient(AppsApi.class).getUsersApp().execute().body();
+        assertEquals(app.getIdentifier(), SHARED_APP_ID);
         
         admin.getClient(AuthenticationApi.class).changeApp(API_SIGNIN).execute();
+        app = admin.getClient(AppsApi.class).getUsersApp().execute().body();
+        assertEquals(app.getIdentifier(), TEST_APP_ID);
+    }
+    
+    @Test
+    public void nonSynapseSignInCannotSwitchBetweenStudies() throws Exception {
+        try {
+            user = TestUserHelper.createAndSignInUser(OAuthTest.class, true);
+            user.getClient(AuthenticationApi.class).changeApp(SHARED_SIGNIN).execute();
+            fail("Should have throw exception");
+        } catch(UnauthorizedException e) {
+            assertEquals(e.getMessage(), "Account has not authenticated through Synapse.");
+        }
     }
     
     private String getValue(HttpResponse response, String property) throws Exception {

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthTest.java
@@ -84,11 +84,15 @@ public class OAuthTest {
     @Test
     public void signInWithSynapseAccount() throws Exception {
         String oauthClientId = CONFIG.get("synapse.oauth.client.id");
+        String synapseEndpoint = CONFIG.get("synapse.endpoint");
+        if (CONFIG.getEnvironment() == Environment.PRODUCTION) {
+            oauthClientId = CONFIG.get("prod.synapse.oauth.client.id");
+            synapseEndpoint = CONFIG.get("prod.synapse.endpoint");
+        }
         String userEmail = CONFIG.get("synapse.test.user");
         String userPassword = CONFIG.get("synapse.test.user.password");
-        String synapseEndpoint = CONFIG.get("synapse.endpoint");
         String synapseUserId = CONFIG.get("synapse.test.user.id");
-
+        
         developer = TestUserHelper.createAndSignInUser(OAuthTest.class, true,
                 new SignUp().roles(ImmutableList.of(DEVELOPER)).synapseUserId(synapseUserId));
         developer.signOut();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignUpForWorkerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignUpForWorkerTest.java
@@ -38,7 +38,7 @@ public class SignUpForWorkerTest {
     
     @Test
     public void signUpWithExternalIdAndNoAccountSucceeds() throws Exception {
-        TestUser admin = TestUserHelper.getSignedInAdmin();
+        TestUser admin = TestUserHelper.getSignedInAdmin(true);
         ForAdminsApi adminsApi = admin.getClient(ForAdminsApi.class);
         StudiesApi studiesApi = admin.getClient(StudiesApi.class);
         OrganizationsApi orgsApi = admin.getClient(OrganizationsApi.class);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
@@ -40,6 +40,7 @@ import org.sagebionetworks.bridge.rest.model.AndroidAppLink;
 import org.sagebionetworks.bridge.rest.model.App;
 import org.sagebionetworks.bridge.rest.model.AppleAppLink;
 import org.sagebionetworks.bridge.rest.model.ClientInfo;
+import org.sagebionetworks.bridge.rest.model.Environment;
 import org.sagebionetworks.bridge.rest.model.MasterSchedulerConfig;
 import org.sagebionetworks.bridge.rest.model.OAuthProvider;
 import org.sagebionetworks.bridge.rest.model.Phone;
@@ -362,8 +363,11 @@ public class Tests {
         synapseClient.setUsername(CONFIG.get("synapse.test.user"));
         synapseClient.setApiKey(CONFIG.get("synapse.test.user.api.key"));
 
-        // Based on config, we either talk to Synapse Dev (local/dev/staging) or Synapse Prod.
+        // SDK Config does not pick up environment-prefixed property, we must do so here
         String synapseEndpoint = CONFIG.get("synapse.endpoint");
+        if (CONFIG.getEnvironment() == Environment.PRODUCTION) {
+            synapseEndpoint = CONFIG.get("prod.synapse.endpoint");   
+        }
         synapseClient.setAuthEndpoint(synapseEndpoint + "auth/v1");
         synapseClient.setFileEndpoint(synapseEndpoint + "file/v1");
         synapseClient.setRepositoryEndpoint(synapseEndpoint + "repo/v1");

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserManagementTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserManagementTest.java
@@ -37,8 +37,6 @@ public class UserManagementTest {
     @Before
     public void before() throws Exception {
         admin = TestUserHelper.getSignedInAdmin();
-
-        researcher = TestUserHelper.createAndSignInUser(UserManagementTest.class, true, RESEARCHER);
     }
 
     @After
@@ -46,11 +44,12 @@ public class UserManagementTest {
         if (researcher != null) {
             researcher.signOutAndDeleteUser(); //must do before admin session signout    
         }
-        admin.signOut();
     }
 
     @Test
     public void canCreateAndSignOutAndDeleteUser() throws Exception {
+        researcher = TestUserHelper.createAndSignInUser(UserManagementTest.class, true, RESEARCHER);
+
         String email = IntegTestUtils.makeEmail(UserManagementTest.class);
         String password = "P4ssword";
 
@@ -90,42 +89,7 @@ public class UserManagementTest {
         }
     }
     
-    @Test
-    public void canSignInAsAdminAndChangeStudy() throws Exception {
-        // Unfortunately right now, we only have one study, but try all the APIs to make sure you
-        // don't get any mistakes
-        admin.signOut();
-        
-        ForSuperadminsApi superadminApi = admin.getClient(ForSuperadminsApi.class);
-        AuthenticationApi authApi = admin.getClient(AuthenticationApi.class);
-        SignIn signIn = new SignIn().appId(admin.getAppId())
-                .email(admin.getEmail()).password((admin.getPassword()));
-        
-        superadminApi.adminSignIn(signIn).execute().body();
-        App currentApp = admin.getClient(AppsApi.class).getUsersApp().execute().body();
-        assertEquals(TEST_APP_ID, currentApp.getIdentifier());
-        
-        superadminApi = admin.getClient(ForSuperadminsApi.class);
-        authApi.changeApp(SHARED_SIGNIN).execute().body();
-        
-        currentApp = admin.getClient(AppsApi.class).getUsersApp().execute().body();
-        assertEquals(SHARED_APP_ID, currentApp.getIdentifier());
-        
-        // now reverse the order
-        admin.signOut(); // so it's not necessary to switch back to the API study for future tests
-        
-        superadminApi = admin.getClient(ForSuperadminsApi.class);
-        signIn = new SignIn().appId(SHARED_APP_ID)
-                .email(admin.getEmail()).password((admin.getPassword()));
-        
-        superadminApi.adminSignIn(signIn).execute().body();
-        currentApp = admin.getClient(AppsApi.class).getUsersApp().execute().body();
-        assertEquals(SHARED_APP_ID, currentApp.getIdentifier());
-        
-        superadminApi = admin.getClient(ForSuperadminsApi.class);
-        authApi.changeApp(API_SIGNIN).execute().body();
-        
-        currentApp = admin.getClient(AppsApi.class).getUsersApp().execute().body();
-        assertEquals(TEST_APP_ID, currentApp.getIdentifier());
-    }
+    // "canSignInAsAdminAndChangeStudy" is tested by OAuthTest#synapseUserCanSwitchBetweenStudies
+    // without creating accounts that would need to be tied to Synapse IDs.
+
 }


### PR DESCRIPTION
One test (OAuthForWorkerTest) I had to entirely disable for now, as we'll need a valid Synapse ID for the worker being created for the test.