### PR TITLE
Switch to use of api-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # BridgeIntegrationTests
 
-Integration tests for the BridgeServer2 server. Integration tests require bootstrap accounts on the server to execute. All tests run outside of production using a `SUPERADMIN` account. In production, for security reasons, a subset of these tests execute using an `ADMIN` account (marked with the `@Category(IntegrationSmokeTest.class)` class annotation). The `ADMIN` account can’t access all apps, or create worker accounts that can access all apps.
-
-## Setting up your environment to run integration tests
+Integration tests for the BridgeServer2 server. 
 
 The integration tests use the Bridge Java REST SDK, and both the SDK and the tests need some properties to be set in order to run (in the following property files):
 
@@ -21,8 +19,18 @@ The integration tests use the Bridge Java REST SDK, and both the SDK and the tes
     synapse.test.user.password = <password>
     synapse.test.user.api.key = <api key>
 
-Create two bootstrap accounts in each environment, one in the 'api' app and one in the 'shared' app. Each account should have the `synapseUserId` ID set in the `synapse.test.user.id` property. In production these accounts should have the `ADMIN` role and in other environments, these accounts should have the `SUPERADMIN` role.
-
 The **synapse.test.*** keys for environments other than `local` are available in LastPass.
 
-It should be possible at this point to start the server and run the tests (`mvn clean test`).
+## Server configuration
+
+On startup, the `BridgeServer2` server will create the following apps and accounts on start-up if they do not currently exist on the server in your environment:
+
+**In all environments** the bootstrapper creates three apps with the IDs of `api`, `api-2`, and `shared`. The API apps are used solely for testing, while the `shared` app is used to test shared assessment functionality outside of production. In production, `shared` is only used to host our shared assessment library.
+
+It also reads the `admin.email` and `admin.synapse.user.id` properties in the `~/BridgeServer2.conf` file. The `admin.synapse.user.id` property should have the same number as the `synapse.test.user.id` property described above.
+
+**In local, development, and staging environments:** the bootstrapper creates three admin accounts, one in each of the `api`,  `api-2`, and `shared` apps. The accounts will have the role of `SUPERADMIN`.
+
+**In the production environment:** the bootstrapper creates three admin accounts, one in each of the `api`,  `api-2`, and `shared` apps. The accounts will have the role of `ADMIN` (**NOT** `SUPERADMIN`).
+
+Once the Bridge server has started, it should be possible to run the test suite with `mvn clean test`.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The **synapse.test.*** keys for environments other than `local` are available in
 
 ## Server configuration
 
-On startup, the `BridgeServer2` server will create the following apps and accounts on start-up if they do not currently exist on the server in your environment:
+On startup, the `BridgeServer2` server will create the following apps and accounts if they do not currently exist on the server in your environment:
 
 **In all environments** the bootstrapper creates three apps with the IDs of `api`, `api-2`, and `shared`. The API apps are used solely for testing, while the `shared` app is used to test shared assessment functionality outside of production. In production, `shared` is only used to host our shared assessment library.
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>BridgeIntegTestUtils</artifactId>
-            <version>1.2.10</version>
+            <version>1.2.11</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthenticationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthenticationTest.java
@@ -36,6 +36,7 @@ import org.sagebionetworks.bridge.rest.model.StudyParticipant;
 import org.sagebionetworks.bridge.rest.model.UserSessionInfo;
 import org.sagebionetworks.bridge.user.TestUserHelper;
 import org.sagebionetworks.bridge.user.TestUserHelper.TestUser;
+import org.sagebionetworks.bridge.util.IntegTestUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -52,7 +53,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.sagebionetworks.bridge.rest.model.Role.RESEARCHER;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.PHONE;
-import static org.sagebionetworks.bridge.util.IntegTestUtils.SHARED_APP_ID;
+import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_2_ID;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_ID;
 
 @Category(IntegrationSmokeTest.class)
@@ -228,10 +229,10 @@ public class AuthenticationTest {
         // this works fine
         testUser.signInAgain();
 
-        // User the shared app for this test. Can we sign in to the shared app? No.
+        // Use api 2 for this test. Can we sign in to this other app? No.
         // 
         try {
-            SignIn otherAppSignIn = new SignIn().appId(SHARED_APP_ID).email(testUser.getEmail())
+            SignIn otherAppSignIn = new SignIn().appId(TEST_APP_2_ID).email(testUser.getEmail())
                     .password(testUser.getPassword());
             ClientManager otherAppManager = new ClientManager.Builder().withSignIn(otherAppSignIn).build();
             

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/OAuthTest.java
@@ -1,22 +1,16 @@
 package org.sagebionetworks.bridge.sdk.integration;
 
 import static java.lang.String.format;
-import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.*;
-import static org.sagebionetworks.bridge.rest.model.Role.DEVELOPER;
+import static org.sagebionetworks.bridge.sdk.integration.Tests.API_2_SIGNIN;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.API_SIGNIN;
-import static org.sagebionetworks.bridge.sdk.integration.Tests.SHARED_SIGNIN;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.escapeJSON;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.CONFIG;
-import static org.sagebionetworks.bridge.util.IntegTestUtils.SHARED_APP_ID;
+import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_2_ID;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_ID;
-
-import java.util.Set;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.fluent.Request;
@@ -24,7 +18,6 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.sagebionetworks.bridge.rest.ClientManager;
@@ -35,7 +28,6 @@ import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
 import org.sagebionetworks.bridge.rest.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.rest.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.rest.model.App;
-import org.sagebionetworks.bridge.rest.model.AppList;
 import org.sagebionetworks.bridge.rest.model.Environment;
 import org.sagebionetworks.bridge.rest.model.OAuthAuthorizationToken;
 import org.sagebionetworks.bridge.rest.model.SignIn;
@@ -154,9 +146,9 @@ public class OAuthTest {
     @Test
     public void synapseUserCanSwitchBetweenStudies() throws Exception {
         // Use the admin we know to be in two studies.
-        admin.getClient(AuthenticationApi.class).changeApp(SHARED_SIGNIN).execute();
+        admin.getClient(AuthenticationApi.class).changeApp(API_2_SIGNIN).execute();
         App app = admin.getClient(AppsApi.class).getUsersApp().execute().body();
-        assertEquals(app.getIdentifier(), SHARED_APP_ID);
+        assertEquals(app.getIdentifier(), TEST_APP_2_ID);
         
         admin.getClient(AuthenticationApi.class).changeApp(API_SIGNIN).execute();
         app = admin.getClient(AppsApi.class).getUsersApp().execute().body();
@@ -167,7 +159,7 @@ public class OAuthTest {
     public void nonSynapseSignInCannotSwitchBetweenStudies() throws Exception {
         try {
             user = TestUserHelper.createAndSignInUser(OAuthTest.class, true);
-            user.getClient(AuthenticationApi.class).changeApp(SHARED_SIGNIN).execute();
+            user.getClient(AuthenticationApi.class).changeApp(API_2_SIGNIN).execute();
             fail("Should have throw exception");
         } catch(UnauthorizedException e) {
             assertEquals(e.getMessage(), "Account has not authenticated through Synapse.");

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SessionRefreshTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SessionRefreshTest.java
@@ -11,18 +11,18 @@ import org.sagebionetworks.bridge.user.TestUserHelper;
 
 import static org.junit.Assert.fail;
 import static org.sagebionetworks.bridge.rest.model.Role.DEVELOPER;
-import static org.sagebionetworks.bridge.util.IntegTestUtils.SHARED_APP_ID;
+import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_2_ID;
 
 import org.joda.time.DateTime;
 
 public class SessionRefreshTest {
     private static TestUserHelper.TestUser user;
-    private static TestUserHelper.TestUser sharedDeveloper;
+    private static TestUserHelper.TestUser app2Developer;
 
     @BeforeClass
     public static void createUser() throws Exception {
         user = TestUserHelper.createAndSignInUser(SessionRefreshTest.class, false);
-        sharedDeveloper = TestUserHelper.createAndSignInUser(SessionRefreshTest.class, SHARED_APP_ID, DEVELOPER);
+        app2Developer = TestUserHelper.createAndSignInUser(SessionRefreshTest.class, TEST_APP_2_ID, DEVELOPER);
     }
 
     @AfterClass
@@ -30,8 +30,8 @@ public class SessionRefreshTest {
         if (user != null) {
             user.signOutAndDeleteUser();
         }
-        if (sharedDeveloper != null) {
-            sharedDeveloper.signOutAndDeleteUser();
+        if (app2Developer != null) {
+            app2Developer.signOutAndDeleteUser();
         }
     }
 
@@ -57,12 +57,12 @@ public class SessionRefreshTest {
     @Test
     public void testReauthenticationAcrossStudies() throws Exception {
         // Use developer from the Shared app to test across studies. Initial call succeeds.
-        sharedDeveloper.getClient(ParticipantsApi.class).getUsersParticipantRecord(false).execute();
+        app2Developer.getClient(ParticipantsApi.class).getUsersParticipantRecord(false).execute();
 
         // Sign user out.
-        sharedDeveloper.signOut();
+        app2Developer.signOut();
 
         // Call should succeed again. Sign-in happens again behind the scenes
-        sharedDeveloper.getClient(ParticipantsApi.class).getUsersParticipantRecord(false).execute();
+        app2Developer.getClient(ParticipantsApi.class).getUsersParticipantRecord(false).execute();
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignUpForWorkerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignUpForWorkerTest.java
@@ -3,11 +3,11 @@ package org.sagebionetworks.bridge.sdk.integration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.rest.model.SharingScope.NO_SHARING;
+import static org.sagebionetworks.bridge.sdk.integration.Tests.API_2_SIGNIN;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.API_SIGNIN;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.PASSWORD;
-import static org.sagebionetworks.bridge.sdk.integration.Tests.SHARED_SIGNIN;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.SAGE_ID;
-import static org.sagebionetworks.bridge.util.IntegTestUtils.SHARED_APP_ID;
+import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_2_ID;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_ID;
 
 import java.util.Map;
@@ -75,19 +75,19 @@ public class SignUpForWorkerTest {
             }
         }
         
-        // In shared there is only one study, "shared", and so that is the one that is used.
-        signUp = new SignUp().appId(SHARED_APP_ID).dataGroups(ImmutableList.of("test_user"))
+        // In api 2 there is only one study, and so that is the one that is used.
+        signUp = new SignUp().appId(TEST_APP_2_ID).dataGroups(ImmutableList.of("test_user"))
                 .password(PASSWORD).externalId(extId).sharingScope(NO_SHARING);
         try {
             authApi.signUp(signUp).execute();
             
-            authApi.changeApp(SHARED_SIGNIN).execute();
+            authApi.changeApp(API_2_SIGNIN).execute();
             participant = participantsApi.getParticipantByExternalId(extId, false).execute().body();
             assertEquals(1, participant.getExternalIds().size());
             // ... however that study is named differently in different environments.
-            String extIdValue = participant.getExternalIds().get("shared-study");
+            String extIdValue = participant.getExternalIds().get("api-2-study");
             if (extIdValue == null) {
-                extIdValue = participant.getExternalIds().get("shared");
+                extIdValue = participant.getExternalIds().get("api-2");
             }
             assertEquals(extId, extIdValue);
             adminsApi.deleteUser(participant.getId()).execute();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
@@ -7,6 +7,7 @@ import static org.sagebionetworks.bridge.rest.model.ActivityEventUpdateType.FUTU
 import static org.sagebionetworks.bridge.rest.model.ActivityEventUpdateType.MUTABLE;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.CONFIG;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.SHARED_APP_ID;
+import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_2_ID;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_ID;
 
 import java.io.IOException;
@@ -57,6 +58,7 @@ public class Tests {
     private static final Logger LOG = LoggerFactory.getLogger(Tests.class);
 
     public static final SignIn API_SIGNIN = new SignIn().appId(TEST_APP_ID);
+    public static final SignIn API_2_SIGNIN = new SignIn().appId(TEST_APP_2_ID);
     public static final SignIn SHARED_SIGNIN = new SignIn().appId(SHARED_APP_ID);
     public static final String PACKAGE = "org.sagebionetworks.bridge";
     public static final String MOBILE_APP_NAME = "DummyApp";

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadTest.java
@@ -5,10 +5,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.sagebionetworks.bridge.sdk.integration.Tests.API_2_SIGNIN;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.API_SIGNIN;
-import static org.sagebionetworks.bridge.sdk.integration.Tests.SHARED_SIGNIN;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.STUDY_ID_1;
-import static org.sagebionetworks.bridge.util.IntegTestUtils.SHARED_APP_ID;
+import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_2_ID;
 
 import java.io.File;
 import java.util.List;
@@ -43,7 +43,6 @@ import org.sagebionetworks.bridge.rest.model.RecordExportStatusRequest;
 import org.sagebionetworks.bridge.rest.model.Role;
 import org.sagebionetworks.bridge.rest.model.SharingScope;
 import org.sagebionetworks.bridge.rest.model.SignUp;
-import org.sagebionetworks.bridge.rest.model.Study;
 import org.sagebionetworks.bridge.rest.model.StudyParticipant;
 import org.sagebionetworks.bridge.rest.model.SynapseExporterStatus;
 import org.sagebionetworks.bridge.rest.model.Upload;
@@ -55,7 +54,6 @@ import org.sagebionetworks.bridge.rest.model.UploadSchemaType;
 import org.sagebionetworks.bridge.rest.model.UploadSession;
 import org.sagebionetworks.bridge.rest.model.UploadStatus;
 import org.sagebionetworks.bridge.rest.model.UploadValidationStatus;
-import org.sagebionetworks.bridge.rest.model.VersionHolder;
 import org.sagebionetworks.bridge.user.TestUserHelper;
 import org.sagebionetworks.bridge.util.IntegTestUtils;
 
@@ -85,20 +83,12 @@ public class UploadTest {
     public static void beforeClass() throws Exception {
         admin = TestUserHelper.getSignedInAdmin();
 
-//        try {
-//            admin.getClient(ForAdminsApi.class).getStudy(STUDY_ID_1).execute();
-//        } catch(EntityNotFoundException e) {
-//            Study study = new Study().name(STUDY_ID_1).identifier(STUDY_ID_1);
-//            VersionHolder version = admin.getClient(ForAdminsApi.class).createStudy(study).execute().body();
-//            study.setVersion(version.getVersion());
-//        }
-        
         // developer is to ensure schemas exist. user is to do uploads
         developer = TestUserHelper.createAndSignInUser(UploadTest.class, false, Role.DEVELOPER);
         researcher = TestUserHelper.createAndSignInUser(UploadTest.class, false, Role.RESEARCHER);
 
-        admin.getClient(AuthenticationApi.class).changeApp(SHARED_SIGNIN).execute();
-        otherAppAdmin = TestUserHelper.createAndSignInUser(UploadTest.class, SHARED_APP_ID, Role.ADMIN);
+        admin.getClient(AuthenticationApi.class).changeApp(API_2_SIGNIN).execute();
+        otherAppAdmin = TestUserHelper.createAndSignInUser(UploadTest.class, TEST_APP_2_ID, Role.ADMIN);
         admin.getClient(AuthenticationApi.class).changeApp(API_SIGNIN).execute();
 
         String emailAddress = IntegTestUtils.makeEmail(UploadTest.class);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserManagementTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserManagementTest.java
@@ -1,26 +1,18 @@
 package org.sagebionetworks.bridge.sdk.integration;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.sagebionetworks.bridge.rest.model.Role.RESEARCHER;
-import static org.sagebionetworks.bridge.sdk.integration.Tests.API_SIGNIN;
-import static org.sagebionetworks.bridge.sdk.integration.Tests.SHARED_SIGNIN;
-import static org.sagebionetworks.bridge.util.IntegTestUtils.SHARED_APP_ID;
-import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_ID;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.rest.ClientManager;
-import org.sagebionetworks.bridge.rest.api.AppsApi;
 import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
 import org.sagebionetworks.bridge.rest.exceptions.EntityAlreadyExistsException;
-import org.sagebionetworks.bridge.rest.model.App;
 import org.sagebionetworks.bridge.rest.model.SignIn;
 import org.sagebionetworks.bridge.rest.api.ForAdminsApi;
-import org.sagebionetworks.bridge.rest.api.ForSuperadminsApi;
 import org.sagebionetworks.bridge.rest.api.ParticipantsApi;
 import org.sagebionetworks.bridge.rest.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.rest.model.SignUp;
@@ -91,5 +83,4 @@ public class UserManagementTest {
     
     // "canSignInAsAdminAndChangeStudy" is tested by OAuthTest#synapseUserCanSwitchBetweenStudies
     // without creating accounts that would need to be tied to Synapse IDs.
-
 }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/WorkerApiTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/WorkerApiTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.sagebionetworks.bridge.rest.model.Role.WORKER;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.STUDY_ID_1;
-import static org.sagebionetworks.bridge.util.IntegTestUtils.SHARED_APP_ID;
+import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_2_ID;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_ID;
 
 import java.util.List;
@@ -349,8 +349,8 @@ public class WorkerApiTest {
     @Test
     public void retrieveUsersBetweenApps() throws Exception {
         AuthenticationApi authApi = admin.getClient(AuthenticationApi.class);
-        authApi.changeApp(new SignIn().appId(SHARED_APP_ID)).execute();
-        TestUser sharedUser = new TestUserHelper.Builder(WorkerApiTest.class).withAppId(SHARED_APP_ID).createUser();
+        authApi.changeApp(new SignIn().appId(TEST_APP_2_ID)).execute();
+        TestUser sharedUser = new TestUserHelper.Builder(WorkerApiTest.class).withAppId(TEST_APP_2_ID).createUser();
         
         authApi.changeApp(new SignIn().appId(TEST_APP_ID)).execute();
         TestUser testUser = new TestUserHelper.Builder(WorkerApiTest.class).withAppId(TEST_APP_ID).createUser();
@@ -362,14 +362,14 @@ public class WorkerApiTest {
             ForWorkersApi workerApi = worker.getClient(ForWorkersApi.class);
             
             // First verify that list methods work...
-            AccountSummaryList sharedList = workerApi.getParticipantsForApp(SHARED_APP_ID, 0, 50, null, null, null, null).execute().body();
+            AccountSummaryList sharedList = workerApi.getParticipantsForApp(TEST_APP_2_ID, 0, 50, null, null, null, null).execute().body();
             assertUserInList(sharedList.getItems(), sharedUser.getUserId());
             
             AccountSummaryList apiList = workerApi.getParticipantsForApp(TEST_APP_ID, 0, 50, null, null, null, null).execute().body();
             assertUserInList(apiList.getItems(), testUser.getUserId());
             
             // Getting individual accounts also works
-            StudyParticipant p1 = workerApi.getParticipantByIdForApp(SHARED_APP_ID, sharedUser.getUserId(), false).execute().body();
+            StudyParticipant p1 = workerApi.getParticipantByIdForApp(TEST_APP_2_ID, sharedUser.getUserId(), false).execute().body();
             assertEquals(sharedUser.getUserId(), p1.getId());
             
             StudyParticipant p2 = workerApi.getParticipantByIdForApp(TEST_APP_ID, testUser.getUserId(), false).execute().body();
@@ -380,7 +380,7 @@ public class WorkerApiTest {
             search.endTime(DateTime.now().plusHours(1));
             
             AccountSummaryList sharedSearchList = workerApi.searchAccountSummariesForApp(
-                    SHARED_APP_ID, search).execute().body();
+                    TEST_APP_2_ID, search).execute().body();
             assertUserInList(sharedSearchList.getItems(), sharedUser.getUserId());
             
             AccountSummaryList testSearchList = workerApi.searchAccountSummariesForApp(


### PR DESCRIPTION
Smoke tests are switched to use api-2 which is not a production app like shared. I also changed other tests that were just in need of a second app, and not really testing the functionality of the shared app (shared assessments and modules). Those are only run outside of the production environment, however.