### PR TITLE
Create an AdminUserService (BRIDGE-3267)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.24.11</version>
+            <version>0.25.2</version>
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.24.10</version>
+            <version>0.24.11</version>
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks</groupId>

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AccountsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AccountsTest.java
@@ -130,7 +130,8 @@ public class AccountsTest {
                 .languages(ImmutableList.of("en", "fr"))
                 .password(PASSWORD)
                 .note("test note 1")
-                .clientTimeZone("America/Los_Angeles");
+                .clientTimeZone("America/Los_Angeles")
+                .orgMembership(orgAdmin.getSession().getOrgMembership());
         
         emailUserId = orgAdminApi.createAccount(account).execute().body().getIdentifier();
         

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ForStudyCoordinatorsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ForStudyCoordinatorsTest.java
@@ -32,7 +32,6 @@ import org.sagebionetworks.bridge.rest.api.ForStudyCoordinatorsApi;
 import org.sagebionetworks.bridge.rest.api.StudiesApi;
 import org.sagebionetworks.bridge.rest.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.rest.exceptions.EntityNotFoundException;
-import org.sagebionetworks.bridge.rest.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.rest.model.AccountSummaryList;
 import org.sagebionetworks.bridge.rest.model.AccountSummarySearch;
 import org.sagebionetworks.bridge.rest.model.ConsentSignature;
@@ -291,18 +290,9 @@ public class ForStudyCoordinatorsTest {
         user = TestUserHelper.createAndSignInUser(ForStudyCoordinatorsTest.class, false);
         coordApi.enrollParticipant(studyId, new Enrollment().userId(user.getUserId())).execute();
         
-        // User is not a test user so this fails
-        try {
-            coordApi.deleteStudyParticipant(studyId, user.getUserId()).execute();
-            fail("Should have thrown an exception");
-        } catch(UnauthorizedException e) {
-        }
+        // We can no longer test that non-test accounts won't be deleted, because all accounts
+        // created through the admin API must be test accounts for security reasons.
         
-        StudyParticipant participant = coordApi.getStudyParticipantById(studyId, user.getUserId(), false).execute().body();
-        participant.setDataGroups(ImmutableList.of("test_user"));
-        coordApi.updateStudyParticipant(studyId, user.getUserId(), participant).execute();
-        
-        // this now succeeds
         coordApi.deleteStudyParticipant(studyId, user.getUserId()).execute();
         
         try {

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ForStudyCoordinatorsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ForStudyCoordinatorsTest.java
@@ -32,6 +32,7 @@ import org.sagebionetworks.bridge.rest.api.ForStudyCoordinatorsApi;
 import org.sagebionetworks.bridge.rest.api.StudiesApi;
 import org.sagebionetworks.bridge.rest.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.rest.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.rest.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.rest.model.AccountSummaryList;
 import org.sagebionetworks.bridge.rest.model.AccountSummarySearch;
 import org.sagebionetworks.bridge.rest.model.ConsentSignature;
@@ -290,9 +291,18 @@ public class ForStudyCoordinatorsTest {
         user = TestUserHelper.createAndSignInUser(ForStudyCoordinatorsTest.class, false);
         coordApi.enrollParticipant(studyId, new Enrollment().userId(user.getUserId())).execute();
         
-        // We can no longer test that non-test accounts won't be deleted, because all accounts
-        // created through the admin API must be test accounts for security reasons.
+        // User is not a test user so this fails
+        try {
+            coordApi.deleteStudyParticipant(studyId, user.getUserId()).execute();
+            fail("Should have thrown an exception");
+        } catch(UnauthorizedException e) {
+        }
         
+        StudyParticipant participant = coordApi.getStudyParticipantById(studyId, user.getUserId(), false).execute().body();
+        participant.setDataGroups(ImmutableList.of("test_user"));
+        coordApi.updateStudyParticipant(studyId, user.getUserId(), participant).execute();
+        
+        // this now succeeds
         coordApi.deleteStudyParticipant(studyId, user.getUserId()).execute();
         
         try {

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/HealthDataEx3Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/HealthDataEx3Test.java
@@ -151,7 +151,7 @@ public class HealthDataEx3Test {
 
         // Test get api for self.
         HealthDataRecordEx3 expectedRecordForSelf = record;
-        HealthDataRecordEx3 retrievedRecordForSelf = consentedUsersApi.getRecordEx3ById(recordId).execute().body();
+        HealthDataRecordEx3 retrievedRecordForSelf = consentedUsersApi.getRecordEx3ById(recordId, null).execute().body();
         assertEquals(expectedRecordForSelf, retrievedRecordForSelf);
 
         // Test List by user for self.

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserParticipantTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserParticipantTest.java
@@ -10,7 +10,6 @@ import static org.sagebionetworks.bridge.sdk.integration.Tests.assertListsEqualI
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 
 import org.junit.After;
 import org.junit.Before;

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserParticipantTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserParticipantTest.java
@@ -10,15 +10,17 @@ import static org.sagebionetworks.bridge.sdk.integration.Tests.assertListsEqualI
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
+import org.sagebionetworks.bridge.rest.api.AccountsApi;
 import org.sagebionetworks.bridge.rest.api.ForConsentedUsersApi;
 import org.sagebionetworks.bridge.rest.api.ForResearchersApi;
 import org.sagebionetworks.bridge.rest.api.ParticipantsApi;
+import org.sagebionetworks.bridge.rest.model.Account;
 import org.sagebionetworks.bridge.rest.model.Role;
 import org.sagebionetworks.bridge.rest.model.StudyParticipant;
 import org.sagebionetworks.bridge.rest.model.UserSessionInfo;
@@ -36,19 +38,23 @@ import java.util.List;
 @Category(IntegrationSmokeTest.class)
 public class UserParticipantTest {
 
+    private static TestUser user;
     private static TestUser developer;
     private static TestUser researcher;
     private static TestUser consentedUser;
 
     @Before
     public void before() throws Exception {
-        developer = TestUserHelper.createAndSignInUser(UserParticipantTest.class, true, Role.DEVELOPER);
-        researcher = TestUserHelper.createAndSignInUser(UserParticipantTest.class, true, Role.RESEARCHER);
+        developer = TestUserHelper.createAndSignInUser(UserParticipantTest.class, false, Role.DEVELOPER);
+        researcher = TestUserHelper.createAndSignInUser(UserParticipantTest.class, false, Role.RESEARCHER);
         consentedUser = TestUserHelper.createAndSignInUser(UserParticipantTest.class, true);
     }
 
     @After
     public void after() throws Exception {
+        if (user != null) {
+            user.signOutAndDeleteUser();
+        }
         if (developer != null) {
             developer.signOutAndDeleteUser();    
         }
@@ -62,43 +68,40 @@ public class UserParticipantTest {
 
     @Test
     public void canUpdateProfile() throws Exception {
-        TestUser user = TestUserHelper.createAndSignInUser(UserParticipantTest.class, true);
-        try {
-            ParticipantsApi participantsApi = user.getClient(ParticipantsApi.class);
+        user = TestUserHelper.createAndSignInUser(UserParticipantTest.class, true);
 
-            StudyParticipant participant = participantsApi.getUsersParticipantRecord(false).execute().body();
+        ParticipantsApi participantsApi = user.getClient(ParticipantsApi.class);
 
-            // This should be true by default, once a participant is created:
-            assertTrue(participant.isNotifyByEmail());
-            
-            participant.setFirstName("Davey");
-            participant.setLastName("Crockett");
-            participant.setAttributes(new ImmutableMap.Builder<String,String>().put("can_be_recontacted","true").build());
-            participant.setNotifyByEmail(null); // this should have no effect
-            participantsApi.updateUsersParticipantRecord(participant).execute().body();
+        StudyParticipant participant = participantsApi.getUsersParticipantRecord(false).execute().body();
 
-            participant = participantsApi.getUsersParticipantRecord(false).execute().body();
-            assertEquals("Davey", participant.getFirstName());
-            assertEquals("Crockett", participant.getLastName());
-            assertEquals("true", participant.getAttributes().get("can_be_recontacted"));
-            // This should not have been changed as the result of updating other fields
-            assertTrue(participant.isNotifyByEmail());
-            
-            // Now update only some of the record but verify the map is still there
-            participant = participantsApi.getUsersParticipantRecord(false).execute().body();
-            participant.setFirstName("Davey2");
-            participant.setLastName("Crockett2");
-            participant.setNotifyByEmail(false);
-            participantsApi.updateUsersParticipantRecord(participant).execute().body();
-            
-            participant = participantsApi.getUsersParticipantRecord(false).execute().body();
-            assertEquals("First name updated", "Davey2", participant.getFirstName());
-            assertEquals("Last name updated", "Crockett2", participant.getLastName());
-            assertEquals("true", participant.getAttributes().get("can_be_recontacted"));
-            assertFalse(participant.isNotifyByEmail());
-        } finally {
-            user.signOutAndDeleteUser();
-        }
+        // This should be true by default, once a participant is created:
+        assertTrue(participant.isNotifyByEmail());
+        
+        participant.setFirstName("Davey");
+        participant.setLastName("Crockett");
+        participant.setAttributes(new ImmutableMap.Builder<String,String>().put("can_be_recontacted","true").build());
+        participant.setNotifyByEmail(null); // this should have no effect
+        participantsApi.updateUsersParticipantRecord(participant).execute().body();
+
+        participant = participantsApi.getUsersParticipantRecord(false).execute().body();
+        assertEquals("Davey", participant.getFirstName());
+        assertEquals("Crockett", participant.getLastName());
+        assertEquals("true", participant.getAttributes().get("can_be_recontacted"));
+        // This should not have been changed as the result of updating other fields
+        assertTrue(participant.isNotifyByEmail());
+        
+        // Now update only some of the record but verify the map is still there
+        participant = participantsApi.getUsersParticipantRecord(false).execute().body();
+        participant.setFirstName("Davey2");
+        participant.setLastName("Crockett2");
+        participant.setNotifyByEmail(false);
+        participantsApi.updateUsersParticipantRecord(participant).execute().body();
+        
+        participant = participantsApi.getUsersParticipantRecord(false).execute().body();
+        assertEquals("First name updated", "Davey2", participant.getFirstName());
+        assertEquals("Last name updated", "Crockett2", participant.getLastName());
+        assertEquals("true", participant.getAttributes().get("can_be_recontacted"));
+        assertFalse(participant.isNotifyByEmail());
     }
 
     @Test
@@ -106,31 +109,27 @@ public class UserParticipantTest {
         String externalId1 = Tests.randomIdentifier(getClass());
         String externalId2 = Tests.randomIdentifier(getClass());
         
-        TestUser user = new TestUserHelper.Builder(UserParticipantTest.class)
+        user = new TestUserHelper.Builder(UserParticipantTest.class)
                 .withExternalIds(ImmutableMap.of(STUDY_ID_1, externalId1)).createAndSignInUser();
         
-        try {
-            ForConsentedUsersApi usersApi = user.getClient(ForConsentedUsersApi.class);
-            StudyParticipant participant = usersApi.getUsersParticipantRecord(false).execute().body();
-            assertEquals(externalId1, participant.getExternalIds().get(STUDY_ID_1));
+        ForConsentedUsersApi usersApi = user.getClient(ForConsentedUsersApi.class);
+        StudyParticipant participant = usersApi.getUsersParticipantRecord(false).execute().body();
+        assertEquals(externalId1, participant.getExternalIds().get(STUDY_ID_1));
 
-            UserSessionInfo session = usersApi.updateUsersParticipantRecord(participant).execute().body();
-            assertEquals(externalId1, session.getExternalIds().get(STUDY_ID_1));
+        UserSessionInfo session = usersApi.updateUsersParticipantRecord(participant).execute().body();
+        assertEquals(externalId1, session.getExternalIds().get(STUDY_ID_1));
 
-            participant = usersApi.getUsersParticipantRecord(false).execute().body();
-            assertEquals(user.getEmail(), participant.getEmail());
-            assertTrue(participant.getExternalIds().values().contains(externalId1));
-            
-            // This doesn't do anything
-            participant.setExternalIds(ImmutableMap.of(STUDY_ID_2, externalId2));
-            usersApi.updateUsersParticipantRecord(participant).execute();
-            
-            StudyParticipant retValue = usersApi.getUsersParticipantRecord(false).execute().body();
-            assertEquals(externalId1, retValue.getExternalIds().get(STUDY_ID_1));
-            assertNull(retValue.getExternalIds().get(STUDY_ID_2));
-        } finally {
-            user.signOutAndDeleteUser();
-        }
+        participant = usersApi.getUsersParticipantRecord(false).execute().body();
+        assertEquals(user.getEmail(), participant.getEmail());
+        assertTrue(participant.getExternalIds().values().contains(externalId1));
+        
+        // This doesn't do anything
+        participant.setExternalIds(ImmutableMap.of(STUDY_ID_2, externalId2));
+        usersApi.updateUsersParticipantRecord(participant).execute();
+        
+        StudyParticipant retValue = usersApi.getUsersParticipantRecord(false).execute().body();
+        assertEquals(externalId1, retValue.getExternalIds().get(STUDY_ID_1));
+        assertNull(retValue.getExternalIds().get(STUDY_ID_2));
     }
     
     @Test
@@ -164,29 +163,28 @@ public class UserParticipantTest {
 
     @Test
     public void canUpdateDataGroupsDoesNotOverrideTestFlag() throws Exception {
-        // Developer in this test is set as a test user.
-        List<String> dataGroups = ImmutableList.of("sdk-int-1", "sdk-int-2", "test_user");
+        user = new TestUserHelper.Builder(UserParticipantTest.class)
+                .withTestDataGroup().withConsentUser(true).createAndSignInUser();
 
-        ForConsentedUsersApi usersApi = developer.getClient(ForConsentedUsersApi.class);
+        ForConsentedUsersApi usersApi = user.getClient(ForConsentedUsersApi.class);
 
+        List<String> dataGroups = ImmutableList.of("sdk-int-1", "sdk-int-2");
         StudyParticipant participant = new StudyParticipant();
         participant.setDataGroups(dataGroups);
         usersApi.updateUsersParticipantRecord(participant).execute();
 
-        developer.signOut();
-        developer.signInAgain();
+        user.signOut();
+        user.signInAgain();
         
-        // Because this is only a developer, their own account is modified to be a test account
-        // on update.
         participant = usersApi.getUsersParticipantRecord(false).execute().body();
-        assertListsEqualIgnoringOrder(dataGroups, participant.getDataGroups());
+        participant.getDataGroups().contains("test_user");
 
         // now clear the values, it should be possible to remove all but the test_user.
         participant.setDataGroups(ImmutableList.of());
         usersApi.updateUsersParticipantRecord(participant).execute();
         
-        developer.signOut();
-        developer.signInAgain();
+        user.signOut();
+        user.signInAgain();
 
         participant = usersApi.getUsersParticipantRecord(false).execute().body();
         assertEquals(ImmutableList.of("test_user"), participant.getDataGroups());
@@ -218,22 +216,18 @@ public class UserParticipantTest {
 
     @Test
     public void adminCanUpdateAndViewSelfNote() throws Exception {
-        ForResearchersApi researchersApi = researcher.getClient(ForResearchersApi.class);
-        StudyParticipant researcherParticipant = researchersApi.getParticipantById(researcher.getUserId(), false)
-                .execute().body();
-        researcherParticipant.setNote("original note");
-        researchersApi.updateParticipant(researcher.getUserId(), researcherParticipant).execute();
+        AccountsApi accountsApi = researcher.getClient(AccountsApi.class);
+        Account researcherAccount = accountsApi.getAccountForSelf().execute().body();
+        researcherAccount.setNote("original note");
+        
+        accountsApi.updateAccountForSelf(researcherAccount).execute();
 
-        ParticipantsApi adminParticipantsApi = researcher.getClient(ParticipantsApi.class);
-
-        StudyParticipant preUpdateParticipant = adminParticipantsApi.getUsersParticipantRecord(false)
-                .execute().body();
-        preUpdateParticipant.setNote("updated note");
-        adminParticipantsApi.updateUsersParticipantRecord(preUpdateParticipant).execute();
+        Account preUpdateAccount = accountsApi.getAccountForSelf().execute().body();
+        preUpdateAccount.setNote("updated note");
+        accountsApi.updateAccountForSelf(preUpdateAccount).execute();
 
         // Verifying note is updated and viewable in an administrative role
-        StudyParticipant updatedParticipant = adminParticipantsApi.getUsersParticipantRecord(false)
-                .execute().body();
-        assertEquals("updated note", updatedParticipant.getNote());
+        Account updatedAccount = accountsApi.getAccountForSelf().execute().body();
+        assertEquals("updated note", updatedAccount.getNote());
     }
 }


### PR DESCRIPTION
The integration tests can no longer use combined admin/participant accounts, so these have had to be split apart. Some other clean up once I had to create more accounts to use our most recent approach to cleaning up accounts.