### PR TITLE
Change Exporter3Test to use bridge-base Config, not JavaSDK Config

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/Exporter3Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/Exporter3Test.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.PASSWORD;
 import static org.sagebionetworks.bridge.sdk.integration.Tests.STUDY_ID_1;
-import static org.sagebionetworks.bridge.util.IntegTestUtils.CONFIG;
 import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_ID;
 
 import java.io.IOException;
@@ -45,6 +44,7 @@ import org.sagebionetworks.repo.model.table.TableEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.sagebionetworks.bridge.config.Config;
 import org.sagebionetworks.bridge.json.DefaultObjectMapper;
 import org.sagebionetworks.bridge.rest.ApiClientProvider;
 import org.sagebionetworks.bridge.rest.api.AccountsApi;
@@ -95,17 +95,19 @@ public class Exporter3Test {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
+        Config config = Tests.loadTestConfig();
+
         synapseClient = Tests.getSynapseClient();
         admin = TestUserHelper.getSignedInAdmin();
         adminsApi = admin.getClient(ForAdminsApi.class);
         oneHourAgo = DateTime.now().minusHours(1);
-        testQueueArn = CONFIG.get("integ.test.queue.arn");
-        testQueueUrl = CONFIG.get("integ.test.queue.url");
+        testQueueArn = config.get("integ.test.queue.arn");
+        testQueueUrl = config.get("integ.test.queue.url");
         workersApi = admin.getClient(ForWorkersApi.class);
 
         // Set up AWS clients.
-        AWSCredentials awsCredentials = new BasicAWSCredentials(CONFIG.get("aws.key"),
-                CONFIG.get("aws.secret.key"));
+        AWSCredentials awsCredentials = new BasicAWSCredentials(config.get("aws.key"),
+                config.get("aws.secret.key"));
         AWSCredentialsProvider awsCredentialsProvider = new AWSStaticCredentialsProvider(awsCredentials);
 
         snsClient = AmazonSNSClientBuilder.standard().withCredentials(awsCredentialsProvider).build();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/Tests.java
@@ -12,6 +12,9 @@ import static org.sagebionetworks.bridge.util.IntegTestUtils.TEST_APP_ID;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -31,6 +34,8 @@ import org.sagebionetworks.client.SynapseClientImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.sagebionetworks.bridge.config.Config;
+import org.sagebionetworks.bridge.config.PropertiesConfig;
 import org.sagebionetworks.bridge.rest.ApiClientProvider;
 import org.sagebionetworks.bridge.rest.ClientManager;
 import org.sagebionetworks.bridge.rest.RestUtils;
@@ -76,6 +81,12 @@ public class Tests {
 
     private static final int RETRY_MAX_TRIES = 5;
     private static final long RETRY_SLEEP_MILLIS = 1000;
+
+    private static final String CONFIG_FILE = "bridge-sdk-test.properties";
+    private static final String DEFAULT_CONFIG_FILE = CONFIG_FILE;
+    private static final String USER_CONFIG_FILE = System.getProperty("user.home") + "/" + CONFIG_FILE;
+
+    private static Config config;
 
     public static ClientInfo getClientInfoWithVersion(String osName, int version) {
         return new ClientInfo().appName(APP_NAME).appVersion(version).deviceName(APP_NAME).osName(osName)
@@ -357,6 +368,20 @@ public class Tests {
 
     public static <T> void assertListsEqualIgnoringOrder(List<T> list1, List<T> list2) {
         assertEquals(ImmutableSet.copyOf(list1), ImmutableSet.copyOf(list2));
+    }
+
+    public static Config loadTestConfig() throws IOException {
+        if (config != null) {
+            return config;
+        }
+
+        Path localConfigPath = Paths.get(USER_CONFIG_FILE);
+        if (Files.exists(localConfigPath)) {
+            config = new PropertiesConfig(DEFAULT_CONFIG_FILE, localConfigPath);
+        } else {
+            config = new PropertiesConfig(DEFAULT_CONFIG_FILE);
+        }
+        return config;
     }
 
     public static SynapseClient getSynapseClient() throws IOException {


### PR DESCRIPTION
JavaSDK Config cannot accept new config values through Env Vars without maintaining a hardcoded list of Env Vars in JavaSDK. This is especially important for maintaining Integ Tests.

This change switches to use bridge-base Config, which is consistent with Server, Worker, and Worker Integ tests. Since the vast majority of config in JavaSDK is actually used by Integ Tests, the goal is to eventually migrate all our configs to use bridge-base.