### PR TITLE
Fix new enrollment alerts tests

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AlertsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AlertsTest.java
@@ -31,6 +31,7 @@ import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
 import org.sagebionetworks.bridge.rest.api.SchedulesV2Api;
 import org.sagebionetworks.bridge.rest.api.StudiesApi;
 import org.sagebionetworks.bridge.rest.exceptions.ConsentRequiredException;
+import org.sagebionetworks.bridge.rest.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.rest.model.ActivityEventUpdateType;
 import org.sagebionetworks.bridge.rest.model.AdherenceRecord;
 import org.sagebionetworks.bridge.rest.model.AdherenceRecordUpdates;
@@ -164,7 +165,10 @@ public class AlertsTest {
         deleteAlerts();
 
         // delete external id
-        adminsApi.deleteExternalId(EXTERNAL_ID).execute();
+        try {
+            adminsApi.deleteExternalId(EXTERNAL_ID).execute();
+        } catch (EntityNotFoundException e) {
+        }
 
         // delete users
         researcher.signOutAndDeleteUser();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AlertsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AlertsTest.java
@@ -19,7 +19,6 @@ import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.sagebionetworks.bridge.rest.ApiClientProvider;
 import org.sagebionetworks.bridge.rest.api.AlertsApi;
@@ -198,7 +197,6 @@ public class AlertsTest {
         } while (alerts.getItems().size() > 0);
     }
 
-    @Ignore
     @Test
     public void newEnrollment() throws IOException {
         // user was already been enrolled in study when account was created
@@ -399,7 +397,6 @@ public class AlertsTest {
         assertNoMatchingAlerts(alertsAfterEvent, CategoryEnum.STUDY_BURST_CHANGE, user.getUserId());
     }
 
-    @Ignore
     @Test
     public void filtering() throws IOException {
         // clear existing alerts
@@ -461,7 +458,6 @@ public class AlertsTest {
         assertOneMatchingAlert(alerts, Alert.CategoryEnum.TIMELINE_ACCESSED, user.getUserId());
     }
 
-    @Ignore
     @Test
     public void readUnreadAndCategoryCounts() throws IOException {
         // clear existing alerts


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/MTB-651

Re-enables new enrollment alert tests and adds an additional test for enrollments being added before an account is created. See [corresponding Bridge Server PR](https://github.com/Sage-Bionetworks/BridgeServer2/pull/645) for additional explanation.

All tests that previously failed now pass on my machine.