### PR TITLE
Fix AlertsTest to clean up assessments

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AlertsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AlertsTest.java
@@ -158,7 +158,7 @@ public class AlertsTest {
 
         // delete assessment
         if (assessment != null) {
-            developersApi.deleteAssessment(assessment.getGuid(), true);
+            adminsApi.deleteAssessment(assessment.getGuid(), true).execute();
         }
 
         // delete alerts


### PR DESCRIPTION
AlertsTest wasn't cleaning up assessments because (a) we forgot to put .execute() and (b) only admins can physically delete asessments.