### PR TITLE
BRIDGE-3281 Disable Exporter3Test.exportTimelineForStudy

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/Exporter3Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/Exporter3Test.java
@@ -46,6 +46,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.exceptions.SynapseException;
@@ -815,6 +816,7 @@ public class Exporter3Test {
     }
 
     @Test
+    @Ignore
     public void exportTimelineForStudy() throws Exception {
         // Set up assessment.
         assessment = new Assessment().title(StudyBurstTest.class.getSimpleName()).osName("Universal").ownerId(SAGE_ID)


### PR DESCRIPTION
Exporter3Test.exportTimelineForStudy() is failing. Disabling this test for now while Lingfei fixes it.

See https://sagebionetworks.jira.com/browse/BRIDGE-3281