### PR TITLE
clean up Synapse resources for study tests in Exporter3Test

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/Exporter3Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/Exporter3Test.java
@@ -241,6 +241,7 @@ public class Exporter3Test {
         StudiesApi studiesApi = admin.getClient(StudiesApi.class);
         Study study = studiesApi.getStudy(Tests.STUDY_ID_1).execute().body();
         Exporter3Configuration ex3ConfigForStudy = study.getExporter3Configuration();
+        deleteEx3Resources(ex3ConfigForStudy);
 
         if (ex3ConfigForStudy != null) {
             study.setExporter3Configuration(null);


### PR DESCRIPTION
We're leaving behind a bunch of test resources in Synapse Dev. Turns out we were missing a line for cleaning up Synapse resources.